### PR TITLE
fix: Inconsistency between Nbt::read and Nbt::write

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ use bytes::Bytes;
 use crab_nbt::{nbt, Nbt, NbtCompound};
 
 fn example(bytes: &mut Bytes) {
-    let nbt = Nbt::read(bytes, false).unwrap();
+    let nbt = Nbt::read(bytes).unwrap();
     let egg_name = nbt
         .get_compound("nbt_inner")
         .and_then(|compound| compound.get_compound("egg"))

--- a/src/nbt/root_nbt.rs
+++ b/src/nbt/root_nbt.rs
@@ -19,20 +19,32 @@ impl Nbt {
         }
     }
 
-    pub fn read(bytes: &mut Bytes, is_network: bool) -> Result<Nbt, Error> {
+    pub fn read(bytes: &mut Bytes) -> Result<Nbt, Error> {
         let tag_type_id = bytes.get_u8();
 
         if tag_type_id != COMPOUND_ID {
             return Err(Error::NoRootCompound(tag_type_id));
         }
 
-        let mut compound_name = String::new();
-        if !is_network {
-            compound_name = get_nbt_string(bytes).unwrap();
-        }
+        let compound_name = get_nbt_string(bytes)?;
 
         Ok(Nbt {
             name: compound_name,
+            root_tag: NbtCompound::deserialize(bytes),
+        })
+    }
+
+    /// Reads Nbt tag, that doesn't contain the name of root compound
+    /// Used in [Network NBT](https://wiki.vg/NBT#Network_NBT_(Java_Edition))
+    pub fn read_unnamed(bytes: &mut Bytes) -> Result<Nbt, Error> {
+        let tag_type_id = bytes.get_u8();
+
+        if tag_type_id != COMPOUND_ID {
+            return Err(Error::NoRootCompound(tag_type_id));
+        }
+
+        Ok(Nbt {
+            name: String::new(),
             root_tag: NbtCompound::deserialize(bytes),
         })
     }

--- a/tests/tag.rs
+++ b/tests/tag.rs
@@ -22,7 +22,7 @@ fn serialize_named() {
 #[test]
 fn deserialize_bigtest() {
     let bytes = Bytes::from(include_bytes!("data/bigtest.nbt") as &[u8]);
-    let nbt = Nbt::read(&mut bytes.clone(), false).unwrap();
+    let nbt = Nbt::read(&mut bytes.clone()).unwrap();
     let egg_name = nbt
         .get_compound("nested compound test")
         .and_then(|compound| compound.get_compound("egg"))
@@ -43,7 +43,7 @@ fn network_nbt() {
 
     let bytes = expected_nbt.write_unnamed();
 
-    let nbt = Nbt::read(&mut bytes.clone(), true).unwrap();
+    let nbt = Nbt::read_unnamed(&mut bytes.clone()).unwrap();
 
     assert_eq!(nbt, expected_nbt);
 }


### PR DESCRIPTION
You forgot to change `Nbt::read` when changing `Nbt::write`
also: don't create a release after this, because I think I might have another fix / thing for CrabNBT soon