### PR TITLE
refactor: Overhaul and clean up the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,6 @@ fn main() {
         }
     });
 
-    // The macro can also take variables to use data calculated at runtime
-    let var_as_key = "some_key".to_owned();
-    let other_key = "other_key".to_owned();
-    let value = vec![0, 1, 2];
-    let other_value = vec![3, 2, 1];
-    let nbt =  nbt!("root", {
-        var_as_key: "wohoo!",
-        "the_other_way": value,
-        other_key: other_value,
-    });
-
     let nbt = Nbt::new(
         "root".to_owned(),
         NbtCompound::from_iter([

--- a/README.md
+++ b/README.md
@@ -27,21 +27,33 @@ fn main() {
     let nbt = nbt!("root nbt_inner name", {
         "float": 1.0,
         "key": "value",
-        "long_array": [L; 1],
-        "int_array": [Int; 1],
+        "long_array": [L; 1, 2],
+        "int_array": [Int; 1, 10, 25],
+        "byte_array": [B; 0, 1, 0, 0, 1],
         "list": ["a", "b", "c"],
         "nbt_inner": {
             "key": "sub value"
         }
     });
 
+    // The macro can also take variables to use data calculated at runtime
+    let var_as_key = "some_key".to_owned();
+    let other_key = "other_key".to_owned();
+    let value = vec![0, 1, 2];
+    let other_value = vec![3, 2, 1];
+    let nbt =  nbt!("root", {
+        var_as_key: "wohoo!",
+        "the_other_way": value,
+        other_key: other_value,
+    });
+
     let nbt = Nbt::new(
-        "root",
-        NbtCompound::from_values(vec![
-            ("float", 1.0.into()),
-            ("key", "value".into()),
-            ("nbt_inner", NbtCompound::from_values(vec![
-                ("key", "sub value".into()),
+        "root".to_owned(),
+        NbtCompound::from_iter([
+            ("float".to_owned(), 1.0.into()),
+            ("key".to_owned(), "value".into()),
+            ("nbt_inner".to_owned(), NbtCompound::from_iter([
+                ("key".to_owned(), "sub value".into()),
             ]).into())
         ])
     );

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Copy, Clone, Debug)]
 pub enum Error {
     #[error("The root tag of the NBT file is not a compound tag. Received tag id: {0}")]
     NoRootCompound(u8),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,7 @@ mod macros;
 mod nbt;
 
 pub use crab_nbt::nbt::compound::NbtCompound;
-pub use crab_nbt::nbt::root_nbt::Nbt;
 pub use crab_nbt::nbt::tag::NbtTag;
-
-#[cfg(test)]
-#[path = "../tests/mod.rs"]
-mod tests;
+pub use crab_nbt::nbt::Nbt;
 
 extern crate self as crab_nbt;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,9 +29,9 @@
 /// let value = vec![0, 1, 2];
 /// let other_value = vec![3, 2, 1];
 /// let nbt =  nbt!("root", {
-/// var_as_key: "wohoo!",
-/// "the_other_way": value,
-/// other_key: other_value,
+///     var_as_key: "wohoo!",
+///     "the_other_way": value,
+///     other_key: other_value,
 /// });
 /// ```
 ///

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -8,15 +8,30 @@
 /// ```
 /// use crab_nbt::nbt;
 ///
-/// let nbt = nbt!("root", {
+/// let key = "key".to_owned();
+/// let value: Vec<u8> = vec![0, 1, 2, 3];
+/// let nbt = nbt!("root nbt_inner name", {
 ///     "float": 1.0,
-///     "key": "value",
-///     "long_array": [L; 1],
-///     "int_array": [Int; 1],
+///     key: "value",
+///     "long_array": [L; 1, 2],
+///     "int_array": [Int; 1, 10, 25],
+///     "byte_array": [B; 0, 1, 0, 0, 1],
 ///     "list": ["a", "b", "c"],
 ///     "nbt_inner": {
 ///         "key": "sub value"
-///     }
+///     },
+///     "byte_array": value,
+/// });
+///
+/// // The macro can also take variables to use data calculated at runtime
+/// let var_as_key = "some_key".to_owned();
+/// let other_key = "other_key".to_owned();
+/// let value = vec![0, 1, 2];
+/// let other_value = vec![3, 2, 1];
+/// let nbt =  nbt!("root", {
+/// var_as_key: "wohoo!",
+/// "the_other_way": value,
+/// other_key: other_value,
 /// });
 /// ```
 ///
@@ -33,6 +48,9 @@
 #[cfg(feature = "macro")]
 #[macro_export]
 macro_rules! nbt {
+    ($name:literal, $content:tt) => {
+        $crate::Nbt::new($name.to_owned(), $crate::nbt_inner!($content))
+    };
     ($name:expr, $content:tt) => {
         $crate::Nbt::new($name, $crate::nbt_inner!($content))
     };
@@ -43,7 +61,7 @@ macro_rules! nbt {
 #[macro_export(local_inner_macros)]
 macro_rules! nbt_inner {
     ({ $($key:tt : $value:tt),* $(,)? }) => {
-        $crate::NbtCompound::new({
+        $crate::NbtCompound::from_iter({
             #[allow(unused_mut)]
             let mut map = ::std::collections::HashMap::<::std::string::String, $crate::NbtTag>::new();
             $(map.insert($key.into(), nbt_inner!(@value $value));)*
@@ -60,6 +78,10 @@ macro_rules! nbt_inner {
     ([I; $($lit:literal),* $(,)?]) => { nbt_inner!([Int; $($lit),*]) };
     ([Int; $($lit:literal),* $(,)?]) => {
         $crate::NbtTag::IntArray(::std::vec![$($lit),*])
+    };
+    ([B; $($lit:literal),* $(,)?]) => { nbt_inner!([Byte; $($lit),*]) };
+    ([Byte; $($lit:literal),* $(,)?]) => {
+        $crate::NbtTag::ByteArray(::std::vec![$($lit),*])
     };
     ([$($lit:literal),* $(,)?]) => {
         $crate::NbtTag::List(::std::vec![$($lit.into()),*])

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -33,7 +33,7 @@ impl Nbt {
 
         Ok(Nbt {
             name: get_nbt_string(bytes)?,
-            root_tag: NbtCompound::deserialize_data(bytes)?,
+            root_tag: NbtCompound::deserialize_content(bytes)?,
         })
     }
 
@@ -48,7 +48,7 @@ impl Nbt {
 
         Ok(Nbt {
             name: String::new(),
-            root_tag: NbtCompound::deserialize_data(bytes)?,
+            root_tag: NbtCompound::deserialize_content(bytes)?,
         })
     }
 
@@ -56,8 +56,7 @@ impl Nbt {
         let mut bytes = BytesMut::new();
         bytes.put_u8(COMPOUND_ID);
         bytes.put(NbtTag::String(self.name.to_string()).serialize_data());
-
-        bytes.put(self.root_tag.serialize_data());
+        bytes.put(self.root_tag.serialize_content());
         bytes.freeze()
     }
 
@@ -66,7 +65,7 @@ impl Nbt {
     pub fn write_unnamed(&self) -> Bytes {
         let mut bytes = BytesMut::new();
         bytes.put_u8(COMPOUND_ID);
-        bytes.put(self.root_tag.serialize_data());
+        bytes.put(self.root_tag.serialize_content());
         bytes.freeze()
     }
 }

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -9,7 +9,7 @@ pub mod compound;
 pub mod tag;
 mod utils;
 
-/// Representation of the root nbt tag.
+/// The root nbt tag.
 #[derive(Clone, PartialEq, Debug, Default)]
 pub struct Nbt {
     pub name: String,
@@ -33,12 +33,12 @@ impl Nbt {
 
         Ok(Nbt {
             name: get_nbt_string(bytes)?,
-            root_tag: NbtCompound::deserialize_raw(bytes)?,
+            root_tag: NbtCompound::deserialize_data(bytes)?,
         })
     }
 
-    /// Reads Nbt tag, that doesn't contain the name of root compound
-    /// Used in [Network NBT](https://wiki.vg/NBT#Network_NBT_(Java_Edition))
+    /// Reads Nbt tag, that doesn't contain the name of root compound.
+    /// Used in [Network NBT](https://wiki.vg/NBT#Network_NBT_(Java_Edition)).
     pub fn read_unnamed(bytes: &mut Bytes) -> Result<Nbt, Error> {
         let tag_type_id = bytes.get_u8();
 
@@ -48,25 +48,25 @@ impl Nbt {
 
         Ok(Nbt {
             name: String::new(),
-            root_tag: NbtCompound::deserialize_raw(bytes)?,
+            root_tag: NbtCompound::deserialize_data(bytes)?,
         })
     }
 
     pub fn write(&self) -> Bytes {
         let mut bytes = BytesMut::new();
         bytes.put_u8(COMPOUND_ID);
-        bytes.put(NbtTag::String(self.name.to_string()).serialize_raw());
+        bytes.put(NbtTag::String(self.name.to_string()).serialize_data());
 
-        bytes.put(self.root_tag.serialize_raw());
+        bytes.put(self.root_tag.serialize_data());
         bytes.freeze()
     }
 
-    /// Writes Nbt tag, without name of root compound
-    /// Used in [Network NBT](https://wiki.vg/NBT#Network_NBT_(Java_Edition))
+    /// Writes Nbt tag, without name of root compound.
+    /// Used in [Network NBT](https://wiki.vg/NBT#Network_NBT_(Java_Edition)).
     pub fn write_unnamed(&self) -> Bytes {
         let mut bytes = BytesMut::new();
         bytes.put_u8(COMPOUND_ID);
-        bytes.put(self.root_tag.serialize_raw());
+        bytes.put(self.root_tag.serialize_data());
         bytes.freeze()
     }
 }

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -84,9 +84,13 @@ impl From<NbtCompound> for Nbt {
     }
 }
 
-impl AsRef<NbtCompound> for Nbt {
-    fn as_ref(&self) -> &NbtCompound {
-        &self.root_tag
+impl<T> AsRef<T> for Nbt
+where
+    T: ?Sized,
+    <Nbt as Deref>::Target: AsRef<T>,
+{
+    fn as_ref(&self) -> &T {
+        self.deref().as_ref()
     }
 }
 

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -138,3 +138,10 @@ impl Extend<(String, NbtTag)> for NbtCompound {
         self.child_tags.extend(iter)
     }
 }
+
+// Rust's AsRef is currently not reflexive so we need to implement it manually
+impl AsRef<NbtCompound> for NbtCompound {
+    fn as_ref(&self) -> &NbtCompound {
+        self
+    }
+}

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -6,22 +6,19 @@ use std::collections::{hash_map::IntoIter, HashMap};
 
 use crate::{error::Error, Nbt};
 
-/// Compound of named nbt tags.
 #[derive(Clone, PartialEq, Debug, Default, Into)]
 pub struct NbtCompound {
     pub child_tags: HashMap<String, NbtTag>,
 }
 
 impl NbtCompound {
-    /// Creates new, empty compound.
     pub fn new() -> NbtCompound {
         NbtCompound {
             child_tags: HashMap::new(),
         }
     }
 
-    /// Deserializes compound data from bytes.
-    pub fn deserialize_data(bytes: &mut Bytes) -> Result<NbtCompound, Error> {
+    pub fn deserialize_content(bytes: &mut Bytes) -> Result<NbtCompound, Error> {
         let mut child_tags = HashMap::new();
 
         while !bytes.is_empty() {
@@ -42,12 +39,11 @@ impl NbtCompound {
         Ok(NbtCompound { child_tags })
     }
 
-    /// Serializes compounds content into bytes.
-    pub fn serialize_data(&self) -> Bytes {
+    pub fn serialize_content(&self) -> Bytes {
         let mut bytes = BytesMut::new();
         for (name, tag) in &self.child_tags {
             bytes.put_u8(tag.id());
-            bytes.put(NbtTag::String(name.to_string()).serialize_data());
+            bytes.put(NbtTag::String(name.clone()).serialize_data());
             bytes.put(tag.serialize_data());
         }
         bytes.put_u8(END_ID);

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -13,15 +13,15 @@ pub struct NbtCompound {
 }
 
 impl NbtCompound {
-    /// Creates new, empty compound
+    /// Creates new, empty compound.
     pub fn new() -> NbtCompound {
         NbtCompound {
             child_tags: HashMap::new(),
         }
     }
 
-    /// Reads compound data from bytes
-    pub fn deserialize_raw(bytes: &mut Bytes) -> Result<NbtCompound, Error> {
+    /// Deserializes compound data from bytes.
+    pub fn deserialize_data(bytes: &mut Bytes) -> Result<NbtCompound, Error> {
         let mut child_tags = HashMap::new();
 
         while !bytes.is_empty() {
@@ -32,7 +32,7 @@ impl NbtCompound {
 
             let name = get_nbt_string(bytes)?;
 
-            if let Ok(tag) = NbtTag::deserialize_raw(bytes, tag_id) {
+            if let Ok(tag) = NbtTag::deserialize_data(bytes, tag_id) {
                 child_tags.insert(name, tag);
             } else {
                 break;
@@ -42,13 +42,13 @@ impl NbtCompound {
         Ok(NbtCompound { child_tags })
     }
 
-    /// Writes compound data into bytes
-    pub fn serialize_raw(&self) -> Bytes {
+    /// Serializes compounds content into bytes.
+    pub fn serialize_data(&self) -> Bytes {
         let mut bytes = BytesMut::new();
         for (name, tag) in &self.child_tags {
             bytes.put_u8(tag.id());
-            bytes.put(NbtTag::String(name.to_string()).serialize_raw());
-            bytes.put(tag.serialize_raw());
+            bytes.put(NbtTag::String(name.to_string()).serialize_data());
+            bytes.put(tag.serialize_data());
         }
         bytes.put_u8(END_ID);
         bytes.freeze()

--- a/src/nbt/mod.rs
+++ b/src/nbt/mod.rs
@@ -1,4 +1,0 @@
-pub mod compound;
-pub mod root_nbt;
-pub mod tag;
-mod utils;

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -66,7 +66,7 @@ impl NbtTag {
                 }
             }
             NbtTag::Compound(compound) => {
-                bytes.put(compound.serialize_data());
+                bytes.put(compound.serialize_content());
             }
             NbtTag::IntArray(int_array) => {
                 bytes.put_i32(int_array.len() as i32);
@@ -135,7 +135,7 @@ impl NbtTag {
                 }
                 Ok(NbtTag::List(list))
             }
-            COMPOUND_ID => Ok(NbtTag::Compound(NbtCompound::deserialize_data(bytes)?)),
+            COMPOUND_ID => Ok(NbtTag::Compound(NbtCompound::deserialize_content(bytes)?)),
             INT_ARRAY_ID => {
                 let len = bytes.get_i32() as usize;
                 let mut int_array = Vec::with_capacity(len);

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -42,21 +42,25 @@ fn nbt_macro_panics_on_nonexistent_key() {
 
 #[test]
 fn nbt_macro_complex_object() {
+    let key = "a_key".to_owned();
+    let some_bytes: Vec<u8> = vec![0, 1, 2, 3];
+
     let nbt_expected = Nbt::new(
-        "root",
-        NbtCompound::from_values(vec![
-            ("float", 1.0_f32.into()),
-            ("key", "value".into()),
-            ("long_array", NbtTag::LongArray(vec![1])),
-            ("int_array", NbtTag::IntArray(vec![1])),
+        "root".to_owned(),
+        NbtCompound::from_iter([
+            ("float".to_owned(), 1.0_f32.into()),
+            ("key".to_owned(), "value".into()),
+            ("long_array".to_owned(), NbtTag::LongArray(vec![1])),
+            ("int_array".to_owned(), NbtTag::IntArray(vec![1])),
             (
-                "list",
+                "list".to_owned(),
                 NbtTag::List(vec!["a".into(), "b".into(), "c".into()]),
             ),
             (
-                "nbt_inner",
-                NbtCompound::from_values(vec![("key", "sub value".into())]).into(),
+                "nbt_inner".to_owned(),
+                NbtCompound::from_iter([("key".to_owned(), "sub value".into())]).into(),
             ),
+            (key.clone(), some_bytes.clone().into()),
         ]),
     );
 
@@ -68,7 +72,8 @@ fn nbt_macro_complex_object() {
         "list": ["a", "b", "c"],
         "nbt_inner": {
             "key": "sub value"
-        }
+        },
+        key: some_bytes
     });
 
     assert_eq!(nbt.child_tags, nbt_expected.child_tags);

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,2 +1,0 @@
-mod macros;
-mod tag;

--- a/tests/tag.rs
+++ b/tests/tag.rs
@@ -2,14 +2,14 @@ use bytes::Bytes;
 use crab_nbt::{nbt, Nbt, NbtTag};
 
 #[test]
-fn serialize_raw_string() {
-    let serialized = NbtTag::String("How are you?".to_string()).serialize_raw();
+fn serialize_data_string() {
+    let serialized = NbtTag::String("How are you?".to_string()).serialize_data();
     assert_eq!(serialized.to_vec(), b"\0\x0cHow are you?")
 }
 
 #[test]
-fn serialize_raw() {
-    let serialized = NbtTag::Long(2137).serialize_raw();
+fn serialize_data() {
+    let serialized = NbtTag::Long(2137).serialize_data();
     assert_eq!(serialized.to_vec(), 2137_i64.to_be_bytes().to_vec())
 }
 

--- a/tests/tag.rs
+++ b/tests/tag.rs
@@ -14,12 +14,6 @@ fn serialize_raw() {
 }
 
 #[test]
-fn serialize_named() {
-    let serialized = NbtTag::Long(2137).serialize_named("hi");
-    assert_eq!(serialized.to_vec(), b"\x04\0\x02hi\0\0\0\0\0\0\x08\x59")
-}
-
-#[test]
 fn deserialize_bigtest() {
     let bytes = Bytes::from(include_bytes!("data/bigtest.nbt") as &[u8]);
     let nbt = Nbt::read(&mut bytes.clone()).unwrap();


### PR DESCRIPTION
This pull request does several things at once, because doing them separately would be a chaos and would cause merge conflicts.
What has been done:
- The code has been cleaned up and deduplicated where possible. This includes
    - Moving or renaming methods to follow consistent style
    - `NbtTag::serialize_named` method has been deleted, because it didn't serve any meaningful purpose
    - One file was moved (the one with `Nbt` type)
    - Other misc changes I might have forgot about
- Short doc comments have been added here and there, to explain what's going on
    - Small modification was added to example code and tests to show that the nbt macro can also take variables
- Several modifications were done to better conform to rust api guidelines
    - Some traits that are recommended to be implemented were implemented (e.g. `From`)
    - Some methods now take `String` instead of taking `&str` and calling `to_owned()` due to [C-CALLER-CONTROL](https://rust-lang.github.io/api-guidelines/flexibility.html#caller-decides-where-to-copy-and-place-data-c-caller-control)