### PR TITLE
Use Bytes in NbtTag

### DIFF
--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -85,6 +85,10 @@ impl NbtCompound {
             .and_then(|tag| tag.extract_double())
     }
 
+    pub fn get_bool(&self, name: &str) -> Option<bool> {
+        self.child_tags.get(name).and_then(|tag| tag.extract_bool())
+    }
+
     pub fn get_string(&self, name: &str) -> Option<&String> {
         self.child_tags
             .get(name)

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -204,6 +204,13 @@ impl NbtTag {
         }
     }
 
+    pub fn extract_bool(&self) -> Option<bool> {
+        match self {
+            NbtTag::Byte(byte) => Some(*byte != 0),
+            _ => None,
+        }
+    }
+
     pub fn extract_byte_array(&self) -> Option<Bytes> {
         match self {
             // Note: Bytes are free to clone, so we can hand out an owned type
@@ -257,5 +264,11 @@ impl From<&str> for NbtTag {
 impl From<&[u8]> for NbtTag {
     fn from(value: &[u8]) -> Self {
         NbtTag::ByteArray(Bytes::copy_from_slice(value))
+    }
+}
+
+impl From<bool> for NbtTag {
+    fn from(value: bool) -> Self {
+        NbtTag::Byte(value as i8)
     }
 }


### PR DESCRIPTION
Since we are using the `bytes` crate everywhere in CrabNBT I think it also makes sense to use it when storing the bytes in `NbtTag`.
This also means we can take advantage of zero-copy that the `bytes` crate offers similarly to how we did in #4