### PR TITLE
Fix macro to work with list of compound

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -88,6 +88,7 @@ macro_rules! nbt_inner {
         $crate::NbtTag::List(::std::vec![$($lit.into()),*])
     };
     ([$($t:tt),* $(,)?]) => {
-        $crate::NbtTag::List(::std::vec![$($t.into()),*])
-    }
+        $crate::NbtTag::List(::std::vec![$(nbt_inner!($t).into()),*])
+    };
+
 }


### PR DESCRIPTION
I make possible to make a list of Compound

<details>
  <summary>Example</summary>

```json
"type": "minecraft:trim_pattern",
"value": [
 {
  "name": "minecraft:coast",
  "id": 0,
  "element": {
      "template_item": "minecraft:coast_armor_trim_smithing_template",
      "description": {
          "translate": "trim_pattern.minecraft.coast"
      },
      "asset_id": "minecraft:coast",
      "decal": 0
  }
},
{
  "name": "minecraft:dune",
  "id": 1,
  "element": {
      "template_item": "minecraft:dune_armor_trim_smithing_template",
      "description": {
          "translate": "trim_pattern.minecraft.dune"
      },
      "asset_id": "minecraft:dune",
      "decal": 0
  }
},
{
  "name": "minecraft:eye",
  "id": 2,
  "element": {
      "template_item": "minecraft:eye_armor_trim_smithing_template",
      "description": {
          "translate": "trim_pattern.minecraft.eye"
      },
      "asset_id": "minecraft:eye",
      "decal": 0
  }
},
{
  "name": "minecraft:host",
  "id": 3,
  "element": {
      "template_item": "minecraft:host_armor_trim_smithing_template",
      "description": {
          "translate": "trim_pattern.minecraft.host"
      },
      "asset_id": "minecraft:host",
      "decal": 0
  }
},
...
```
</details>
