### PR TITLE
feat: Add alternative methods, so `Bytes` is not required

### DIFF
--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -3,6 +3,7 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crab_nbt::nbt::compound::NbtCompound;
 use crab_nbt::nbt::tag::NbtTag;
 use crab_nbt::nbt::utils::*;
+use std::io::Cursor;
 use std::ops::Deref;
 
 pub mod compound;
@@ -38,6 +39,10 @@ impl Nbt {
         })
     }
 
+    pub fn read_from_cursor(cursor: &mut Cursor<&[u8]>) -> Result<Nbt, Error> {
+        Self::read(cursor)
+    }
+
     /// Reads NBT tag, that doesn't contain the name of root compound.
     /// Used in [Network NBT](https://wiki.vg/NBT#Network_NBT_(Java_Edition)).
     pub fn read_unnamed(bytes: &mut impl Buf) -> Result<Nbt, Error> {
@@ -53,12 +58,20 @@ impl Nbt {
         })
     }
 
+    pub fn read_unnamed_from_cursor(cursor: &mut Cursor<&[u8]>) -> Result<Nbt, Error> {
+        Self::read_unnamed(cursor)
+    }
+
     pub fn write(&self) -> Bytes {
         let mut bytes = BytesMut::new();
         bytes.put_u8(COMPOUND_ID);
         bytes.put(NbtTag::String(self.name.to_string()).serialize_data());
         bytes.put(self.root_tag.serialize_content());
         bytes.freeze()
+    }
+
+    pub fn write_to_vec(&self, vec: &mut Vec<u8>) {
+        vec.put(self.write());
     }
 
     /// Writes NBT tag, without name of root compound.
@@ -68,6 +81,10 @@ impl Nbt {
         bytes.put_u8(COMPOUND_ID);
         bytes.put(self.root_tag.serialize_content());
         bytes.freeze()
+    }
+
+    pub fn write_unnamed_to_vec(&self, vec: &mut Vec<u8>) {
+        vec.put(self.write_unnamed());
     }
 }
 

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -1,10 +1,10 @@
+use crate::{error::Error, Nbt};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crab_nbt::nbt::tag::NbtTag;
 use crab_nbt::nbt::utils::{get_nbt_string, END_ID};
 use derive_more::Into;
 use std::collections::{hash_map::IntoIter, HashMap};
-
-use crate::{error::Error, Nbt};
+use std::io::Cursor;
 
 #[derive(Clone, PartialEq, Debug, Default, Into)]
 pub struct NbtCompound {
@@ -39,6 +39,12 @@ impl NbtCompound {
         Ok(NbtCompound { child_tags })
     }
 
+    pub fn deserialize_content_from_cursor(
+        cursor: &mut Cursor<&[u8]>,
+    ) -> Result<NbtCompound, Error> {
+        Self::deserialize_content(cursor)
+    }
+
     pub fn serialize_content(&self) -> Bytes {
         let mut bytes = BytesMut::new();
         for (name, tag) in &self.child_tags {
@@ -48,6 +54,10 @@ impl NbtCompound {
         }
         bytes.put_u8(END_ID);
         bytes.freeze()
+    }
+
+    pub fn serialize_content_to_vec(&self, vec: &mut Vec<u8>) {
+        vec.put(self.serialize_content());
     }
 
     pub fn put(&mut self, name: String, value: impl Into<NbtTag>) {

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -3,6 +3,7 @@ use crab_nbt::error::Error;
 use crab_nbt::nbt::compound::NbtCompound;
 use crab_nbt::nbt::utils::*;
 use derive_more::From;
+use std::io::Cursor;
 
 /// Enum representing the different types of NBT tags.
 /// Each variant corresponds to a different type of data that can be stored in an NBT tag.
@@ -88,6 +89,10 @@ impl NbtTag {
         Self::deserialize_data(bytes, tag_id)
     }
 
+    pub fn deserialize_from_cursor(cursor: &mut Cursor<&[u8]>) -> Result<NbtTag, Error> {
+        Self::deserialize(cursor)
+    }
+
     pub fn deserialize_data(bytes: &mut impl Buf, tag_id: u8) -> Result<NbtTag, Error> {
         match tag_id {
             END_ID => Ok(NbtTag::End),
@@ -153,6 +158,13 @@ impl NbtTag {
             }
             _ => Err(Error::UnknownTagId(tag_id)),
         }
+    }
+
+    pub fn deserialize_data_from_cursor(
+        cursor: &mut Cursor<&[u8]>,
+        tag_id: u8,
+    ) -> Result<NbtTag, Error> {
+        Self::deserialize_data(cursor, tag_id)
     }
 
     pub fn extract_byte(&self) -> Option<i8> {

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -40,7 +40,9 @@ impl Serializer {
             }
             State::MapKey => {
                 if tag != STRING_ID {
-                    return Err(Error::SerdeError(format!("Map key can only be string, not {tag}")));
+                    return Err(Error::SerdeError(format!(
+                        "Map key can only be string, not {tag}"
+                    )));
                 }
             }
             State::ListElement => {}
@@ -156,7 +158,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
             self.state = State::Named(v.to_string());
             return Ok(());
         }
-        
+
         self.output
             .put(NbtTag::String(v.to_string()).serialize_data());
         Ok(())

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -81,17 +81,16 @@ enum Message {
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct Text {
     #[serde(flatten)]
-    pub message: Message
+    pub message: Message,
 }
-
 
 #[test]
 fn test_map_cycle() {
     let test = Text {
         message: Message::Request {
             id: "a".to_string(),
-            method: 0
-        }
+            method: 0,
+        },
     };
     let mut bytes = to_bytes_unnamed(&test).unwrap();
     let result: Text = from_bytes_unnamed(&mut bytes).unwrap();


### PR DESCRIPTION
Fixes: #17

This solution, while not perfect, enables full utilization of CrabNBT without needing to include `bytes` crate in your project. 

In future, I'll redesign this to improve performance (writing directly to `Vec` instead of serializing bytes and then pushing it) and usability, but this will require changes to public methods and a new major version (see #18 for details).