### PR TITLE
fix: Allow using `serde` without `bytes` crate

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,11 +2,12 @@
 use serde::{de, ser};
 #[cfg(feature = "serde")]
 use std::fmt::Display;
+use std::io;
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Error, Clone, Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     #[error("The root tag of the NBT file is not a compound tag. Received tag id: {0}")]
     NoRootCompound(u8),
@@ -18,6 +19,8 @@ pub enum Error {
     SerdeError(String),
     #[error("NBT doesn't support this type {0}")]
     UnsupportedType(String),
+    #[error(transparent)]
+    Io(#[from] io::Error),
 }
 
 #[cfg(feature = "serde")]

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -3,7 +3,7 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crab_nbt::nbt::compound::NbtCompound;
 use crab_nbt::nbt::tag::NbtTag;
 use crab_nbt::nbt::utils::*;
-use std::io::Cursor;
+use std::io::{Cursor, Write};
 use std::ops::Deref;
 
 pub mod compound;
@@ -70,8 +70,9 @@ impl Nbt {
         bytes.freeze()
     }
 
-    pub fn write_to_vec(&self, vec: &mut Vec<u8>) {
-        vec.put(self.write());
+    pub fn write_to_writer<W: Write>(&self, mut writer: W) -> Result<(), Error> {
+        writer.write_all(&self.write())?;
+        Ok(())
     }
 
     /// Writes NBT tag, without name of root compound.
@@ -83,8 +84,9 @@ impl Nbt {
         bytes.freeze()
     }
 
-    pub fn write_unnamed_to_vec(&self, vec: &mut Vec<u8>) {
-        vec.put(self.write_unnamed());
+    pub fn write_unnamed_to_writer<W: Write>(&self, mut writer: W) -> Result<(), Error> {
+        writer.write_all(&self.write_unnamed())?;
+        Ok(())
     }
 }
 

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -4,7 +4,7 @@ use crab_nbt::nbt::tag::NbtTag;
 use crab_nbt::nbt::utils::{get_nbt_string, END_ID};
 use derive_more::Into;
 use std::collections::{hash_map::IntoIter, HashMap};
-use std::io::Cursor;
+use std::io::{Cursor, Write};
 
 #[derive(Clone, PartialEq, Debug, Default, Into)]
 pub struct NbtCompound {
@@ -56,8 +56,9 @@ impl NbtCompound {
         bytes.freeze()
     }
 
-    pub fn serialize_content_to_vec(&self, vec: &mut Vec<u8>) {
-        vec.put(self.serialize_content());
+    pub fn serialize_content_to_writer<W: Write>(&self, mut writer: W) -> Result<(), Error> {
+        writer.write_all(&self.serialize_content())?;
+        Ok(())
     }
 
     pub fn put(&mut self, name: String, value: impl Into<NbtTag>) {

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -90,13 +90,13 @@ impl<'de, 'a, T: Buf> de::Deserializer<'de> for &'a mut Deserializer<'de, T> {
 
         let result: Result<V::Value> = Ok(
             match NbtTag::deserialize_data(self.input, tag_to_deserialize)? {
-                NbtTag::Byte(value) => visitor.visit_i8(value)?,
-                NbtTag::Short(value) => visitor.visit_i16(value)?,
-                NbtTag::Int(value) => visitor.visit_i32(value)?,
-                NbtTag::Long(value) => visitor.visit_i64(value)?,
-                NbtTag::Float(value) => visitor.visit_f32(value)?,
-                NbtTag::Double(value) => visitor.visit_f64(value)?,
-                NbtTag::String(value) => visitor.visit_string(value)?,
+                NbtTag::Byte(value) => visitor.visit_i8::<Error>(value)?,
+                NbtTag::Short(value) => visitor.visit_i16::<Error>(value)?,
+                NbtTag::Int(value) => visitor.visit_i32::<Error>(value)?,
+                NbtTag::Long(value) => visitor.visit_i64::<Error>(value)?,
+                NbtTag::Float(value) => visitor.visit_f32::<Error>(value)?,
+                NbtTag::Double(value) => visitor.visit_f64::<Error>(value)?,
+                NbtTag::String(value) => visitor.visit_string::<Error>(value)?,
                 _ => unreachable!(),
             },
         );

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -65,6 +65,13 @@ where
     Ok(serializer.output)
 }
 
+pub fn to_vec_unnamed<T>(value: &T) -> Result<Vec<u8>>
+where
+    T: Serialize,
+{
+    to_bytes_unnamed(value).map(Vec::from)
+}
+
 /// Serializes struct using Serde Serializer to normal NBT
 pub fn to_bytes<T>(value: &T, name: String) -> Result<BytesMut>
 where
@@ -76,6 +83,13 @@ where
     };
     value.serialize(&mut serializer)?;
     Ok(serializer.output)
+}
+
+pub fn to_vec<T>(value: &T, name: String) -> Result<Vec<u8>>
+where
+    T: Serialize,
+{
+    to_bytes(value, name).map(Vec::from)
 }
 
 impl<'a> ser::Serializer for &'a mut Serializer {

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -6,6 +6,7 @@ use bytes::{BufMut, BytesMut};
 use crab_nbt::nbt::utils::END_ID;
 use serde::ser::Impossible;
 use serde::{ser, Serialize};
+use std::io::Write;
 
 pub struct Serializer {
     output: BytesMut,
@@ -65,11 +66,13 @@ where
     Ok(serializer.output)
 }
 
-pub fn to_vec_unnamed<T>(value: &T) -> Result<Vec<u8>>
+pub fn to_writer_unnamed<T, W>(value: &T, mut writer: W) -> Result<()>
 where
     T: Serialize,
+    W: Write
 {
-    to_bytes_unnamed(value).map(Vec::from)
+    writer.write_all(&to_bytes_unnamed(value)?)?;
+    Ok(())
 }
 
 /// Serializes struct using Serde Serializer to normal NBT
@@ -85,11 +88,13 @@ where
     Ok(serializer.output)
 }
 
-pub fn to_vec<T>(value: &T, name: String) -> Result<Vec<u8>>
+pub fn to_writer<T, W>(value: &T, name: String, mut writer: W) -> Result<()>
 where
     T: Serialize,
+    W: Write
 {
-    to_bytes(value, name).map(Vec::from)
+    writer.write_all(&to_bytes(value, name)?)?;
+    Ok(())
 }
 
 impl<'a> ser::Serializer for &'a mut Serializer {


### PR DESCRIPTION
XDDDDD, I forgot about that, sorry:

> The serde functions (which were precisely what I actually need) still use Bytes 😩 😩