### PR TITLE
Implement PartialOrd for nbt types

### DIFF
--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -12,7 +12,7 @@ pub mod utils;
 
 /// Represents the main NBT structure.
 /// It contains the root compound tag of the NBT structure and its associated name
-#[derive(Clone, PartialEq, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, PartialOrd)]
 pub struct Nbt {
     pub name: String,
     pub root_tag: NbtCompound,

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -6,7 +6,7 @@ use derive_more::Into;
 use std::io::{Cursor, Write};
 use std::vec::IntoIter;
 
-#[derive(Clone, PartialEq, Debug, Default, Into)]
+#[derive(Clone, Debug, Default, PartialEq, PartialOrd, Into)]
 pub struct NbtCompound {
     pub child_tags: Vec<(String, NbtTag)>,
 }

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -8,7 +8,7 @@ use std::io::Cursor;
 /// Enum representing the different types of NBT tags.
 /// Each variant corresponds to a different type of data that can be stored in an NBT tag.
 #[repr(u8)]
-#[derive(Clone, PartialEq, Debug, From)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, From)]
 pub enum NbtTag {
     End = END_ID,
     Byte(i8) = BYTE_ID,


### PR DESCRIPTION
~~Changes HashMap to BTreeMap, because HashMaps don't preserver order.~~
Just added derive, because we use Vec now.