### PR TITLE
fix: Alternative way for serializing booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ fn example(bytes: &mut Bytes) {
 
 ```rust
 use crab_nbt::serde::{arrays::IntArray, ser::to_bytes_unnamed, de::from_bytes_unnamed};
+use crab_nbt::serde::bool::deserialize_bool;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
@@ -78,12 +79,17 @@ struct Test {
     number: i32,
     #[serde(with = "IntArray")]
     int_array: Vec<i32>,
+    /// Using [deserialize_bool] is required only if
+    /// you are using `#[serde(flatten)]` attribute 
+    #[serde(deserialize_with = "deserialize_bool")]
+    bool: bool
 }
 
 fn cycle() {
     let test = Test {
         number: 5,
-        int_array: vec![7, 8]
+        int_array: vec![7, 8],
+        bool: false
     };
     let mut bytes = to_bytes_unnamed(&test).unwrap();
     let recreated_struct: Test = from_bytes_unnamed(&mut bytes).unwrap();
@@ -91,3 +97,5 @@ fn cycle() {
     assert_eq!(test, recreated_struct);
 }
 ```
+
+

--- a/src/serde/bool.rs
+++ b/src/serde/bool.rs
@@ -1,0 +1,41 @@
+use core::fmt;
+use serde::de::{Error, Visitor};
+use serde::Deserializer;
+
+pub fn deserialize_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_any(BoolVisitor)
+}
+
+pub fn deserialize_option_bool<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_any(BoolVisitor).map(Some)
+}
+
+pub struct BoolVisitor;
+
+impl Visitor<'_> for BoolVisitor {
+    type Value = bool;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("bool or i8")
+    }
+
+    fn visit_i8<E>(self, value: i8) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(value == 1)
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(value)
+    }
+}

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -166,7 +166,7 @@ struct CompoundAccess<'a, 'de: 'a, T: Buf> {
     de: &'a mut Deserializer<'de, T>,
 }
 
-impl<'de, 'a, T: Buf> MapAccess<'de> for CompoundAccess<'a, 'de, T> {
+impl<'de, T: Buf> MapAccess<'de> for CompoundAccess<'_, 'de, T> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
@@ -197,7 +197,7 @@ struct ListAccess<'a, 'de: 'a, T: Buf> {
     list_type: u8,
 }
 
-impl<'a, 'de, T: Buf> SeqAccess<'de> for ListAccess<'a, 'de, T> {
+impl<'de, T: Buf> SeqAccess<'de> for ListAccess<'_, 'de, T> {
     type Error = Error;
 
     fn next_element_seed<E>(&mut self, seed: E) -> Result<Option<E::Value>>

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,3 +1,4 @@
 pub mod arrays;
+pub mod bool;
 pub mod de;
 pub mod ser;

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -279,6 +279,13 @@ impl ser::Serializer for &mut Serializer {
             }
             _ => {
                 self.parse_state(LIST_ID)?;
+
+                // If list is empty, FirstListElement is never parsed
+                if len.unwrap() == 0 {
+                    self.output.put_u8(END_ID);
+                    self.output.put_i32(0);
+                }
+
                 self.state = State::FirstListElement {
                     len: len.unwrap() as i32,
                 };

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -14,6 +14,7 @@ struct Test {
     array: Vec<i32>,
     list: Vec<i16>,
     sub: Inner,
+    sub_vec: Vec<Inner>,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
@@ -29,6 +30,7 @@ fn test_serialize() {
         array: vec![5, 6, 7],
         list: vec![1, 2, 3],
         sub: Inner { int: 5 },
+        sub_vec: vec![Inner { int: 5 }],
     };
     let expected = nbt!("", {
         "str": "hi ❤️",
@@ -37,7 +39,12 @@ fn test_serialize() {
         "list": [1i16, 2i16, 3i16],
         "sub": {
             "int": 5
-        }
+        },
+        "sub_vec": [
+            {
+                "int": 5
+            }
+        ]
     });
 
     let mut bytes = to_bytes_unnamed(&test).unwrap();
@@ -55,7 +62,8 @@ fn test_deserialize() {
             "list": [1i16, 2i16, 3i16],
             "sub": {
                 "int": 5
-            }
+            },
+            "sub_vec": []
         })
         .write_unnamed()[..],
     );
@@ -65,6 +73,7 @@ fn test_deserialize() {
         array: vec![5, 6, 7],
         list: vec![1, 2, 3],
         sub: Inner { int: 5 },
+        sub_vec: Vec::new(),
     };
 
     let parsed: Test = from_bytes_unnamed(&mut test).unwrap();


### PR DESCRIPTION
Previously, if you had `#[serde(flatten)]` it wouldn't work for booleans, due to how badly serde is implemented.
