### PR TITLE
perf: Performance improvements for arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Cargo.lock
 
 # Flamegraph
 flamegraph.svg
+perf.data*
 
 # Code editors
 .idea/

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -139,22 +139,18 @@ impl NbtTag {
             }
             COMPOUND_ID => Ok(NbtTag::Compound(NbtCompound::deserialize_content(bytes)?)),
             INT_ARRAY_ID => {
+                const BYTES: usize = size_of::<i32>();
+
                 let len = bytes.get_i32() as usize;
-                let mut int_array = Vec::with_capacity(len);
-                for _ in 0..len {
-                    let int = bytes.get_i32();
-                    int_array.push(int);
-                }
-                Ok(NbtTag::IntArray(int_array))
+                let numbers = read_array::<i32, BYTES, _>(bytes, len, i32::from_be_bytes);
+                Ok(NbtTag::IntArray(numbers))
             }
             LONG_ARRAY_ID => {
+                const BYTES: usize = size_of::<i64>();
+
                 let len = bytes.get_i32() as usize;
-                let mut long_array = Vec::with_capacity(len);
-                for _ in 0..len {
-                    let long = bytes.get_i64();
-                    long_array.push(long);
-                }
-                Ok(NbtTag::LongArray(long_array))
+                let numbers = read_array::<i64, BYTES, _>(bytes, len, i64::from_be_bytes);
+                Ok(NbtTag::LongArray(numbers))
             }
             _ => Err(Error::UnknownTagId(tag_id)),
         }

--- a/src/serde/arrays.rs
+++ b/src/serde/arrays.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Deserializer};
 
 /// Crates structs, that allow for serializing fields as arrays (not lists)
-/// ```ignore
-/// #[serde(with = IntArray)]
+/// ```rust ignore
+/// #[serde(with = "IntArray")]
 /// ```
 macro_rules! impl_array {
     ($name:ident, $variant:expr) => {


### PR DESCRIPTION
`read_chunk`:
Time: ((38.2 - 36.7) / 38.2) × 100 ≈ 3.93% faster
Throughput: ((1.12 - 1.08) / 1.08) × 100 ≈ 3.7% higher

`read_serde_chunk`:
Time: ((163 - 38) / 163) × 100 ≈ 76.7% faster
Throughput: ((1.08 GiB - 0.26 GiB) / 0.26 GiB) × 100 ≈ 315% higher

Now for deserializing chunks we are a bit faster than https://github.com/azalea-rs/simdnbt (`1.1257 GiB/s` vs `1.1055 GiB/s`) :3