### PR TITLE
Refactor - remove `bytes` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ serde = ["dep:serde"]
 nightly = ["simd_cesu8/nightly"]
 
 [dependencies]
-bytes = "1.10.0"
 simd_cesu8 = "1.0.1"
 derive_more = { version = "2.0.1", features = ["into", "from"] }
 thiserror = "2.0.11"

--- a/README.md
+++ b/README.md
@@ -53,10 +53,9 @@ let normal_bytes = nbt.write();
 ## Deserializing
 
 ```rust
-use bytes::Bytes;
 use crab_nbt::{nbt, Nbt, NbtCompound};
 
-fn example(bytes: &mut Bytes) {
+fn example(bytes: &[u8]) {
     let nbt = Nbt::read(bytes).unwrap();
     let egg_name = nbt
         .get_compound("nbt_inner")

--- a/benches/read.rs
+++ b/benches/read.rs
@@ -1,4 +1,3 @@
-use bytes::Bytes;
 use crab_nbt::Nbt;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
 
@@ -8,13 +7,13 @@ mod test_data_definitions;
 #[path = "../tests/utils.rs"]
 mod utils;
 
-fn benchmark_file(criterion: &mut Criterion, file_name: &str, bytes: Bytes) {
+fn benchmark_file(criterion: &mut Criterion, file_name: &str, bytes: &[u8]) {
     let mut group = criterion.benchmark_group("read");
     group.throughput(Throughput::Bytes(bytes.len() as u64));
 
     group.bench_function(file_name, |b| {
         b.iter_batched_ref(
-            || bytes.clone(),
+            || bytes,
             |bytes| Nbt::read(bytes).expect("Failed to parse NBT"),
             BatchSize::SmallInput,
         )
@@ -25,16 +24,16 @@ fn benchmark_file(criterion: &mut Criterion, file_name: &str, bytes: Bytes) {
 fn benchmark_file_serde<T: serde::de::DeserializeOwned>(
     criterion: &mut Criterion,
     file_name: &str,
-    bytes: Bytes,
+    bytes: &[u8],
 ) {
     let mut group = criterion.benchmark_group("read_serde");
     group.throughput(Throughput::Bytes(bytes.len() as u64));
 
     group.bench_function(file_name, |b| {
-        b.iter_batched(
-            || bytes.clone(),
-            |mut bytes| {
-                crab_nbt::serde::de::from_bytes::<T>(&mut bytes).expect("Failed to parse NBT");
+        b.iter_batched_ref(
+            || bytes,
+            |bytes| {
+                crab_nbt::serde::de::from_bytes::<T>(bytes).expect("Failed to parse NBT");
             },
             BatchSize::SmallInput,
         )
@@ -43,18 +42,18 @@ fn benchmark_file_serde<T: serde::de::DeserializeOwned>(
 
 fn benchmark(criterion: &mut Criterion) {
     let bytes = utils::read_file("tests/data/complex_player.dat", true);
-    benchmark_file(criterion, "complex_player", Bytes::clone(&bytes));
+    benchmark_file(criterion, "complex_player", &bytes);
     #[cfg(feature = "serde")]
     benchmark_file_serde::<test_data_definitions::ComplexPlayer>(
         criterion,
         "complex_player",
-        bytes,
+        &bytes,
     );
 
     let bytes = utils::read_file("tests/data/chunk.nbt", false);
-    benchmark_file(criterion, "chunk", Bytes::clone(&bytes));
+    benchmark_file(criterion, "chunk", &bytes);
     #[cfg(feature = "serde")]
-    benchmark_file_serde::<test_data_definitions::Chunk>(criterion, "chunk", bytes);
+    benchmark_file_serde::<test_data_definitions::Chunk>(criterion, "chunk", &bytes);
 }
 
 criterion_group!(benches, benchmark);

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,8 @@ pub enum Error {
     UnsupportedType(String),
     #[error(transparent)]
     Io(#[from] io::Error),
+    #[error("Not enough bytes remaining in buffer to read value (requested {requested} but only {available} available)")]
+    NotEnoughBytes { requested: usize, available: usize },
 }
 
 #[cfg(feature = "serde")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,8 @@ pub enum Error {
     Io(#[from] io::Error),
     #[error("Not enough bytes remaining in buffer to read value (requested {requested} but only {available} available)")]
     NotEnoughBytes { requested: usize, available: usize },
+    #[error("Cannot skip {amount} bytes, only {available} bytes are remaining in the buffer")]
+    InvalidSkip { amount: usize, available: usize },
 }
 
 #[cfg(feature = "serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod macros;
 mod nbt;
 #[cfg(feature = "serde")]
 pub mod serde;
+pub mod slice_cursor;
 
 pub use crab_nbt::nbt::compound::NbtCompound;
 pub use crab_nbt::nbt::tag::NbtTag;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ mod macros;
 mod nbt;
 #[cfg(feature = "serde")]
 pub mod serde;
-pub mod slice_cursor;
 
 pub use crab_nbt::nbt::compound::NbtCompound;
 pub use crab_nbt::nbt::tag::NbtTag;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -6,11 +6,10 @@
 /// Basic usage:
 ///
 /// ```
-/// use bytes::Bytes;
 /// use crab_nbt::nbt;
 ///
 /// let key = "key".to_owned();
-/// let value = Bytes::from_iter([0, 1, 2, 3]);
+/// let value = Vec::from_iter([0, 1, 2, 3]);
 /// let nbt = nbt!("root nbt_inner name", {
 ///     "float": 1.0,
 ///     key: "value",
@@ -81,7 +80,7 @@ macro_rules! nbt_inner {
     };
     ([B; $($lit:literal),* $(,)?]) => { nbt_inner!([Byte; $($lit),*]) };
     ([Byte; $($lit:literal),* $(,)?]) => {
-        $crate::NbtTag::ByteArray(::bytes::Bytes::from_iter([$($lit),*]))
+        $crate::NbtTag::ByteArray(::std::vec::Vec::from_iter([$($lit),*]))
     };
     ([$($lit:literal),* $(,)?]) => {
         $crate::NbtTag::List(::std::vec![$($lit.into()),*])

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -34,7 +34,7 @@ impl Nbt {
         }
 
         Ok(Nbt {
-            name: get_nbt_string(&mut bytes)?,
+            name: get_nbt_string(&mut bytes)?.to_string(),
             root_tag: NbtCompound::deserialize_content(&mut bytes)?,
         })
     }

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -1,4 +1,4 @@
-use crate::{error::Error, slice_cursor::BinarySliceCursor};
+use crate::{error::Error, nbt::utils::slice_cursor::BinarySliceCursor};
 use crab_nbt::nbt::compound::NbtCompound;
 use crab_nbt::nbt::tag::NbtTag;
 use crab_nbt::nbt::utils::*;

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -26,7 +26,7 @@ impl NbtCompound {
                 break;
             }
 
-            let name = get_nbt_string(bytes)?;
+            let name = get_nbt_string(bytes)?.to_string();
 
             if let Ok(tag) = NbtTag::deserialize_data(bytes, tag_id) {
                 compound.put(name, tag);

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -1,4 +1,4 @@
-use crate::{error::Error, slice_cursor::BinarySliceCursor, Nbt};
+use crate::{error::Error, nbt::slice_cursor::BinarySliceCursor, Nbt};
 use crab_nbt::nbt::tag::NbtTag;
 use crab_nbt::nbt::utils::{get_nbt_string, END_ID};
 use derive_more::Into;

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -4,7 +4,7 @@ use crab_nbt::nbt::utils::*;
 use derive_more::From;
 use std::io::Cursor;
 
-use crate::slice_cursor::BinarySliceCursor;
+use crate::nbt::slice_cursor::BinarySliceCursor;
 
 /// Enum representing the different types of NBT tags.
 /// Each variant corresponds to a different type of data that can be stored in an NBT tag.

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -126,7 +126,7 @@ impl NbtTag {
                 let byte_array = bytes.read(len)?.to_vec();
                 Ok(NbtTag::ByteArray(byte_array))
             }
-            STRING_ID => Ok(NbtTag::String(get_nbt_string(bytes).unwrap())),
+            STRING_ID => Ok(NbtTag::String(get_nbt_string(bytes).unwrap().to_string())),
             LIST_ID => {
                 let tag_type_id = bytes.read_u8()?;
                 let len = bytes.read_i32_be()?;

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -1,9 +1,10 @@
-use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crab_nbt::error::Error;
 use crab_nbt::nbt::compound::NbtCompound;
 use crab_nbt::nbt::utils::*;
 use derive_more::From;
 use std::io::Cursor;
+
+use crate::slice_cursor::BinarySliceCursor;
 
 /// Enum representing the different types of NBT tags.
 /// Each variant corresponds to a different type of data that can be stored in an NBT tag.
@@ -17,7 +18,7 @@ pub enum NbtTag {
     Long(i64) = LONG_ID,
     Float(f32) = FLOAT_ID,
     Double(f64) = DOUBLE_ID,
-    ByteArray(Bytes) = BYTE_ARRAY_ID,
+    ByteArray(Vec<u8>) = BYTE_ARRAY_ID,
     String(String) = STRING_ID,
     List(Vec<NbtTag>) = LIST_ID,
     Compound(NbtCompound) = COMPOUND_ID,
@@ -32,103 +33,103 @@ impl NbtTag {
         unsafe { *(self as *const Self as *const u8) }
     }
 
-    pub fn serialize(&self) -> Bytes {
-        let mut bytes = BytesMut::new();
-        bytes.put_u8(self.get_type_id());
-        bytes.put(self.serialize_data());
-        bytes.freeze()
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.push(self.get_type_id());
+        bytes.extend(self.serialize_data());
+        bytes
     }
 
-    pub fn serialize_data(&self) -> Bytes {
-        let mut bytes = BytesMut::new();
+    pub fn serialize_data(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
         match self {
             NbtTag::End => {}
-            NbtTag::Byte(byte) => bytes.put_i8(*byte),
-            NbtTag::Short(short) => bytes.put_i16(*short),
-            NbtTag::Int(int) => bytes.put_i32(*int),
-            NbtTag::Long(long) => bytes.put_i64(*long),
-            NbtTag::Float(float) => bytes.put_f32(*float),
-            NbtTag::Double(double) => bytes.put_f64(*double),
+            NbtTag::Byte(byte) => bytes.extend(byte.to_be_bytes()),
+            NbtTag::Short(short) => bytes.extend(short.to_be_bytes()),
+            NbtTag::Int(int) => bytes.extend(int.to_be_bytes()),
+            NbtTag::Long(long) => bytes.extend(long.to_be_bytes()),
+            NbtTag::Float(float) => bytes.extend(float.to_be_bytes()),
+            NbtTag::Double(double) => bytes.extend(double.to_be_bytes()),
             NbtTag::ByteArray(byte_array) => {
-                bytes.put_i32(byte_array.len() as i32);
-                bytes.put_slice(byte_array);
+                bytes.extend((byte_array.len() as i32).to_be_bytes());
+                bytes.extend(byte_array);
             }
             NbtTag::String(string) => {
                 let java_string = simd_cesu8::encode(string);
-                bytes.put_u16(java_string.len() as u16);
-                bytes.put_slice(&java_string);
+                bytes.extend((java_string.len() as u16).to_be_bytes());
+                bytes.extend_from_slice(&java_string[..]);
             }
             NbtTag::List(list) => {
-                bytes.put_u8(list.first().unwrap_or(&NbtTag::End).get_type_id());
-                bytes.put_i32(list.len() as i32);
+                bytes.extend((list.first().unwrap_or(&NbtTag::End).get_type_id()).to_be_bytes());
+                bytes.extend((list.len() as i32).to_be_bytes());
                 for nbt_tag in list {
-                    bytes.put(nbt_tag.serialize_data())
+                    bytes.extend(nbt_tag.serialize_data())
                 }
             }
             NbtTag::Compound(compound) => {
-                bytes.put(compound.serialize_content());
+                bytes.extend(compound.serialize_content());
             }
             NbtTag::IntArray(int_array) => {
-                bytes.put_i32(int_array.len() as i32);
+                bytes.extend((int_array.len() as i32).to_be_bytes());
                 for int in int_array {
-                    bytes.put_i32(*int)
+                    bytes.extend(int.to_be_bytes())
                 }
             }
             NbtTag::LongArray(long_array) => {
-                bytes.put_i32(long_array.len() as i32);
+                bytes.extend((long_array.len() as i32).to_be_bytes());
                 for long in long_array {
-                    bytes.put_i64(*long)
+                    bytes.extend(long.to_be_bytes())
                 }
             }
         }
-        bytes.freeze()
+        bytes
     }
 
-    pub fn deserialize(bytes: &mut impl Buf) -> Result<NbtTag, Error> {
-        let tag_id = bytes.get_u8();
+    pub fn deserialize(bytes: &mut BinarySliceCursor) -> Result<NbtTag, Error> {
+        let tag_id = bytes.read_u8()?;
         Self::deserialize_data(bytes, tag_id)
     }
 
     pub fn deserialize_from_cursor(cursor: &mut Cursor<&[u8]>) -> Result<NbtTag, Error> {
-        Self::deserialize(cursor)
+        Self::deserialize(&mut BinarySliceCursor::new(cursor.get_ref()))
     }
 
-    pub fn deserialize_data(bytes: &mut impl Buf, tag_id: u8) -> Result<NbtTag, Error> {
+    pub fn deserialize_data(bytes: &mut BinarySliceCursor, tag_id: u8) -> Result<NbtTag, Error> {
         match tag_id {
             END_ID => Ok(NbtTag::End),
             BYTE_ID => {
-                let byte = bytes.get_i8();
+                let byte = bytes.read_i8()?;
                 Ok(NbtTag::Byte(byte))
             }
             SHORT_ID => {
-                let short = bytes.get_i16();
+                let short = bytes.read_i16_be()?;
                 Ok(NbtTag::Short(short))
             }
             INT_ID => {
-                let int = bytes.get_i32();
+                let int = bytes.read_i32_be()?;
                 Ok(NbtTag::Int(int))
             }
             LONG_ID => {
-                let long = bytes.get_i64();
+                let long = bytes.read_i64_be()?;
                 Ok(NbtTag::Long(long))
             }
             FLOAT_ID => {
-                let float = bytes.get_f32();
+                let float = bytes.read_f32_be()?;
                 Ok(NbtTag::Float(float))
             }
             DOUBLE_ID => {
-                let double = bytes.get_f64();
+                let double = bytes.read_f64_be()?;
                 Ok(NbtTag::Double(double))
             }
             BYTE_ARRAY_ID => {
-                let len = bytes.get_i32() as usize;
-                let byte_array = bytes.copy_to_bytes(len);
+                let len = bytes.read_i32_be()? as usize;
+                let byte_array = bytes.read(len)?.to_vec();
                 Ok(NbtTag::ByteArray(byte_array))
             }
             STRING_ID => Ok(NbtTag::String(get_nbt_string(bytes).unwrap())),
             LIST_ID => {
-                let tag_type_id = bytes.get_u8();
-                let len = bytes.get_i32();
+                let tag_type_id = bytes.read_u8()?;
+                let len = bytes.read_i32_be()?;
                 let mut list = Vec::with_capacity(len as usize);
                 for _ in 0..len {
                     let tag = NbtTag::deserialize_data(bytes, tag_type_id)?;
@@ -141,15 +142,15 @@ impl NbtTag {
             INT_ARRAY_ID => {
                 const BYTES: usize = size_of::<i32>();
 
-                let len = bytes.get_i32() as usize;
-                let numbers = read_array::<i32, BYTES, _>(bytes, len, i32::from_be_bytes);
+                let len = bytes.read_i32_be()? as usize;
+                let numbers = read_array::<i32, BYTES, _>(bytes, len, i32::from_be_bytes)?;
                 Ok(NbtTag::IntArray(numbers))
             }
             LONG_ARRAY_ID => {
                 const BYTES: usize = size_of::<i64>();
 
-                let len = bytes.get_i32() as usize;
-                let numbers = read_array::<i64, BYTES, _>(bytes, len, i64::from_be_bytes);
+                let len = bytes.read_i32_be()? as usize;
+                let numbers = read_array::<i64, BYTES, _>(bytes, len, i64::from_be_bytes)?;
                 Ok(NbtTag::LongArray(numbers))
             }
             _ => Err(Error::UnknownTagId(tag_id)),
@@ -160,7 +161,7 @@ impl NbtTag {
         cursor: &mut Cursor<&[u8]>,
         tag_id: u8,
     ) -> Result<NbtTag, Error> {
-        Self::deserialize_data(cursor, tag_id)
+        Self::deserialize_data(&mut BinarySliceCursor::new(cursor.get_ref()), tag_id)
     }
 
     pub fn extract_byte(&self) -> Option<i8> {
@@ -212,10 +213,10 @@ impl NbtTag {
         }
     }
 
-    pub fn extract_byte_array(&self) -> Option<Bytes> {
+    pub fn extract_byte_array(&self) -> Option<&Vec<u8>> {
         match self {
             // Note: Bytes are free to clone, so we can hand out an owned type
-            NbtTag::ByteArray(byte_array) => Some(byte_array.clone()),
+            NbtTag::ByteArray(byte_array) => Some(byte_array),
             _ => None,
         }
     }
@@ -264,7 +265,7 @@ impl From<&str> for NbtTag {
 
 impl From<&[u8]> for NbtTag {
     fn from(value: &[u8]) -> Self {
-        NbtTag::ByteArray(Bytes::copy_from_slice(value))
+        NbtTag::ByteArray(value.to_vec())
     }
 }
 

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -1,7 +1,9 @@
 use std::borrow::Cow;
 
-use crate::{error::Error, slice_cursor::BinarySliceCursor};
+use crate::{error::Error, nbt::utils::slice_cursor::BinarySliceCursor};
 use simd_cesu8::decode;
+
+pub(crate) mod slice_cursor;
 
 pub const END_ID: u8 = 0;
 pub const BYTE_ID: u8 = 1;

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{error::Error, slice_cursor::BinarySliceCursor};
 use simd_cesu8::decode;
 
@@ -15,13 +17,10 @@ pub const COMPOUND_ID: u8 = 10;
 pub const INT_ARRAY_ID: u8 = 11;
 pub const LONG_ARRAY_ID: u8 = 12;
 
-pub fn get_nbt_string(bytes: &mut BinarySliceCursor) -> Result<String, Error> {
+pub fn get_nbt_string<'a>(bytes: &'a mut BinarySliceCursor) -> Result<Cow<'a, str>, Error> {
     let len = bytes.read_u16_be()? as usize;
     let string_bytes = bytes.read(len)?;
-    decode(string_bytes)
-        .as_deref()
-        .map(ToOwned::to_owned)
-        .map_err(|_| Error::InvalidJavaString)
+    decode(string_bytes).map_err(|_| Error::InvalidJavaString)
 }
 
 // This can be improved once rust-lang/rust#132980 is resolved:

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -1,5 +1,4 @@
-use crate::error::Error;
-use bytes::Buf;
+use crate::{error::Error, slice_cursor::BinarySliceCursor};
 use simd_cesu8::decode;
 
 pub const END_ID: u8 = 0;
@@ -16,29 +15,31 @@ pub const COMPOUND_ID: u8 = 10;
 pub const INT_ARRAY_ID: u8 = 11;
 pub const LONG_ARRAY_ID: u8 = 12;
 
-pub fn get_nbt_string(bytes: &mut impl Buf) -> Result<String, Error> {
-    let len = bytes.get_u16() as usize;
-    let string_bytes = bytes.copy_to_bytes(len);
-    let string = decode(&string_bytes).map_err(|_| Error::InvalidJavaString)?;
-    Ok(string.to_string())
+pub fn get_nbt_string(bytes: &mut BinarySliceCursor) -> Result<String, Error> {
+    let len = bytes.read_u16_be()? as usize;
+    let string_bytes = bytes.read(len)?;
+    decode(string_bytes)
+        .as_deref()
+        .map(ToOwned::to_owned)
+        .map_err(|_| Error::InvalidJavaString)
 }
 
 // This can be improved once rust-lang/rust#132980 is resolved:
 // Instead of passing `BYTES` manually, we could use const generics, e.g. `size_of::<T>()`.
 pub(crate) fn read_array<T, const N: usize, F>(
-    bytes: &mut impl Buf,
+    bytes: &mut BinarySliceCursor,
     len: usize,
     from_be: F,
-) -> Vec<T>
+) -> Result<Vec<T>, Error>
 where
     F: Fn([u8; N]) -> T,
 {
-    bytes
-        .copy_to_bytes(len * N)
+    Ok(bytes
+        .read(len * N)?
         .chunks_exact(N)
         .map(|chunk| {
             let arr: [u8; N] = chunk.try_into().expect("chunk size mismatch");
             from_be(arr)
         })
-        .collect()
+        .collect())
 }

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -1,8 +1,8 @@
 use crate::error::{Error, Result};
 use crate::nbt::utils::get_nbt_string;
 use crate::nbt::utils::{BYTE_ID, COMPOUND_ID, END_ID, LIST_ID};
+use crate::slice_cursor::BinarySliceCursor;
 use crate::NbtTag;
-use bytes::Buf;
 use serde::de::value::SeqDeserializer;
 use serde::de::{self, DeserializeSeed, IntoDeserializer, MapAccess, SeqAccess, Visitor};
 use serde::{forward_to_deserialize_any, Deserialize};
@@ -10,8 +10,8 @@ use std::io::Cursor;
 use std::vec::IntoIter;
 
 #[derive(Debug)]
-pub struct Deserializer<'de, T: Buf> {
-    input: &'de mut T,
+pub struct Deserializer<'de> {
+    input: BinarySliceCursor<'de>,
     tag_to_deserialize: Option<u8>,
     is_named: bool,
     // Average serde experience, sometimes when you deserialize a struct in a struct
@@ -20,8 +20,8 @@ pub struct Deserializer<'de, T: Buf> {
     is_deserializing_key: bool,
 }
 
-impl<'de, T: Buf> Deserializer<'de, T> {
-    pub fn new(input: &'de mut T, is_named: bool) -> Self {
+impl<'de> Deserializer<'de> {
+    pub fn new(input: BinarySliceCursor<'de>, is_named: bool) -> Self {
         Deserializer {
             input,
             tag_to_deserialize: None,
@@ -32,11 +32,11 @@ impl<'de, T: Buf> Deserializer<'de, T> {
 }
 
 /// Deserializes struct using Serde Deserializer from unnamed (network) NBT
-pub fn from_bytes<'a, T>(s: &'a mut impl Buf) -> Result<T>
+pub fn from_bytes<'a, T>(s: &'a [u8]) -> Result<T>
 where
     T: Deserialize<'a>,
 {
-    let mut deserializer = Deserializer::new(s, true);
+    let mut deserializer = Deserializer::new(BinarySliceCursor::new(s), true);
     T::deserialize(&mut deserializer)
 }
 
@@ -44,16 +44,16 @@ pub fn from_cursor<'a, T>(cursor: &'a mut Cursor<&[u8]>) -> Result<T>
 where
     T: Deserialize<'a>,
 {
-    let mut deserializer = Deserializer::new(cursor, true);
+    let mut deserializer = Deserializer::new(BinarySliceCursor::new(cursor.get_ref()), true);
     T::deserialize(&mut deserializer)
 }
 
 /// Deserializes struct using Serde Deserializer from normal NBT
-pub fn from_bytes_unnamed<'a, T>(s: &'a mut impl Buf) -> Result<T>
+pub fn from_bytes_unnamed<'a, T>(s: &'a [u8]) -> Result<T>
 where
     T: Deserialize<'a>,
 {
-    let mut deserializer = Deserializer::new(s, false);
+    let mut deserializer = Deserializer::new(BinarySliceCursor::new(s), false);
     T::deserialize(&mut deserializer)
 }
 
@@ -61,11 +61,11 @@ pub fn from_cursor_unnamed<'a, T>(cursor: &'a mut Cursor<&[u8]>) -> Result<T>
 where
     T: Deserialize<'a>,
 {
-    let mut deserializer = Deserializer::new(cursor, false);
+    let mut deserializer = Deserializer::new(BinarySliceCursor::new(cursor.get_ref()), false);
     T::deserialize(&mut deserializer)
 }
 
-impl<'de, T: Buf> de::Deserializer<'de> for &mut Deserializer<'de, T> {
+impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
     type Error = Error;
 
     forward_to_deserialize_any!(i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 seq char str string bytes byte_buf tuple tuple_struct enum ignored_any unit unit_struct newtype_struct);
@@ -82,8 +82,8 @@ impl<'de, T: Buf> de::Deserializer<'de> for &mut Deserializer<'de, T> {
         let tag_to_deserialize = self.tag_to_deserialize.unwrap();
         match tag_to_deserialize {
             LIST_ID => {
-                let list_type = self.input.get_u8();
-                let remaining_values = self.input.get_u32();
+                let list_type = self.input.read_u8()?;
+                let remaining_values = self.input.read_u32_be()?;
                 return visitor.visit_seq(ListAccess {
                     de: self,
                     list_type,
@@ -95,7 +95,7 @@ impl<'de, T: Buf> de::Deserializer<'de> for &mut Deserializer<'de, T> {
         };
 
         let result: Result<V::Value> = Ok(
-            match NbtTag::deserialize_data(self.input, tag_to_deserialize)? {
+            match NbtTag::deserialize_data(&mut self.input, tag_to_deserialize)? {
                 NbtTag::Byte(value) => visitor.visit_i8::<Error>(value)?,
                 NbtTag::Short(value) => visitor.visit_i16::<Error>(value)?,
                 NbtTag::Int(value) => visitor.visit_i32::<Error>(value)?,
@@ -131,7 +131,7 @@ impl<'de, T: Buf> de::Deserializer<'de> for &mut Deserializer<'de, T> {
         V: Visitor<'de>,
     {
         if self.tag_to_deserialize.unwrap() == BYTE_ID {
-            let value = self.input.get_u8();
+            let value = self.input.read_u8()?;
             if value != 0 {
                 return visitor.visit_bool(true);
             }
@@ -151,15 +151,15 @@ impl<'de, T: Buf> de::Deserializer<'de> for &mut Deserializer<'de, T> {
         V: Visitor<'de>,
     {
         if self.tag_to_deserialize.is_none() {
-            let next_byte = self.input.get_u8();
+            let next_byte = self.input.read_u8()?;
             if next_byte != COMPOUND_ID {
                 return Err(Error::NoRootCompound(next_byte));
             }
 
             if self.is_named {
                 // Compound name is never used, so we can skip it
-                let length = self.input.get_u16() as usize;
-                self.input.advance(length);
+                let length = self.input.read_u16_be()? as usize;
+                self.input.skip(length);
             }
         }
 
@@ -192,18 +192,19 @@ impl<'de, T: Buf> de::Deserializer<'de> for &mut Deserializer<'de, T> {
     }
 }
 
-struct CompoundAccess<'a, 'de: 'a, T: Buf> {
-    de: &'a mut Deserializer<'de, T>,
+#[derive(Debug)]
+struct CompoundAccess<'a, 'de: 'a> {
+    de: &'a mut Deserializer<'de>,
 }
 
-impl<'de, T: Buf> MapAccess<'de> for CompoundAccess<'_, 'de, T> {
+impl<'de> MapAccess<'de> for CompoundAccess<'_, 'de> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
     where
         K: DeserializeSeed<'de>,
     {
-        let tag = self.de.input.get_u8();
+        let tag = self.de.input.read_u8()?;
         self.de.tag_to_deserialize = Some(tag);
 
         if tag == END_ID {
@@ -223,13 +224,13 @@ impl<'de, T: Buf> MapAccess<'de> for CompoundAccess<'_, 'de, T> {
     }
 }
 
-struct ListAccess<'a, 'de: 'a, T: Buf> {
-    de: &'a mut Deserializer<'de, T>,
+struct ListAccess<'a, 'de: 'a> {
+    de: &'a mut Deserializer<'de>,
     remaining_values: u32,
     list_type: u8,
 }
 
-impl<'de, T: Buf> SeqAccess<'de> for ListAccess<'_, 'de, T> {
+impl<'de> SeqAccess<'de> for ListAccess<'_, 'de> {
     type Error = Error;
 
     fn next_element_seed<E>(&mut self, seed: E) -> Result<Option<E::Value>>

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -1,7 +1,6 @@
 use crate::error::{Error, Result};
 use crate::nbt::utils::get_nbt_string;
-use crate::nbt::utils::{BYTE_ID, COMPOUND_ID, END_ID, LIST_ID};
-use crate::slice_cursor::BinarySliceCursor;
+use crate::nbt::utils::{slice_cursor::BinarySliceCursor, BYTE_ID, COMPOUND_ID, END_ID, LIST_ID};
 use crate::NbtTag;
 use serde::de::value::SeqDeserializer;
 use serde::de::{self, DeserializeSeed, IntoDeserializer, MapAccess, SeqAccess, Visitor};
@@ -53,7 +52,7 @@ where
         BinarySliceCursor::new(&cursor.get_ref()[cursor.position() as usize..]);
     let mut deserializer = Deserializer::from_slice_cursor(slice_cursor, true);
     let result = T::deserialize(&mut deserializer)?;
-    cursor.seek_relative(deserializer.input.pos() as i64)?;
+    cursor.seek_relative(deserializer.input.position() as i64)?;
     Ok(result)
 }
 
@@ -74,7 +73,7 @@ where
         BinarySliceCursor::new(&cursor.get_ref()[cursor.position() as usize..]);
     let mut deserializer = Deserializer::from_slice_cursor(slice_cursor, false);
     let result = T::deserialize(&mut deserializer)?;
-    cursor.seek_relative(deserializer.input.pos() as i64)?;
+    cursor.seek_relative(deserializer.input.position() as i64)?;
     Ok(result)
 }
 
@@ -172,7 +171,7 @@ impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
             if self.is_named {
                 // Compound name is never used, so we can skip it
                 let length = self.input.read_u16_be()? as usize;
-                self.input.skip(length);
+                self.input.skip(length)?;
             }
         }
 

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -184,7 +184,7 @@ impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
         V: Visitor<'de>,
     {
         let str = get_nbt_string(&mut self.input)?;
-        visitor.visit_string(str)
+        visitor.visit_str(&str)
     }
 
     fn is_human_readable(&self) -> bool {

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -96,7 +96,7 @@ impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
         match tag_to_deserialize {
             LIST_ID => {
                 let list_type = self.input.read_u8()?;
-                let remaining_values = self.input.read_u32_be()?;
+                let remaining_values = self.input.read_i32_be()?;
                 return visitor.visit_seq(ListAccess {
                     de: self,
                     list_type,
@@ -239,7 +239,7 @@ impl<'de> MapAccess<'de> for CompoundAccess<'_, 'de> {
 
 struct ListAccess<'a, 'de: 'a> {
     de: &'a mut Deserializer<'de>,
-    remaining_values: u32,
+    remaining_values: i32,
     list_type: u8,
 }
 

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -2,14 +2,13 @@ use crate::error::Error::UnsupportedType;
 use crate::error::{Error, Result};
 use crate::nbt::utils::*;
 use crate::NbtTag;
-use bytes::{BufMut, BytesMut};
 use crab_nbt::nbt::utils::END_ID;
 use serde::ser::Impossible;
 use serde::{ser, Serialize};
 use std::io::Write;
 
 pub struct Serializer {
-    output: BytesMut,
+    output: Vec<u8>,
     state: State,
 }
 
@@ -31,13 +30,13 @@ impl Serializer {
     fn parse_state(&mut self, tag: u8) -> Result<()> {
         match &mut self.state {
             State::Named(name) | State::Array { name, .. } => {
-                self.output.put_u8(tag);
+                self.output.push(tag);
                 self.output
-                    .put(NbtTag::String(name.clone()).serialize_data());
+                    .extend(NbtTag::String(name.clone()).serialize_data());
             }
             State::FirstListElement { len } => {
-                self.output.put_u8(tag);
-                self.output.put_i32(*len);
+                self.output.push(tag);
+                self.output.extend(len.to_be_bytes().iter());
             }
             State::MapKey => {
                 if tag != STRING_ID {
@@ -54,12 +53,12 @@ impl Serializer {
 }
 
 /// Serializes struct using Serde Serializer to unnamed (network) NBT
-pub fn to_bytes_unnamed<T>(value: &T) -> Result<BytesMut>
+pub fn to_bytes_unnamed<T>(value: &T) -> Result<Vec<u8>>
 where
     T: Serialize,
 {
     let mut serializer = Serializer {
-        output: BytesMut::new(),
+        output: Vec::new(),
         state: State::Root(None),
     };
     value.serialize(&mut serializer)?;
@@ -76,12 +75,12 @@ where
 }
 
 /// Serializes struct using Serde Serializer to normal NBT
-pub fn to_bytes<T>(value: &T, name: String) -> Result<BytesMut>
+pub fn to_bytes<T>(value: &T, name: String) -> Result<Vec<u8>>
 where
     T: Serialize,
 {
     let mut serializer = Serializer {
-        output: BytesMut::new(),
+        output: Vec::new(),
         state: State::Root(Some(name)),
     };
     value.serialize(&mut serializer)?;
@@ -117,25 +116,25 @@ impl ser::Serializer for &mut Serializer {
 
     fn serialize_i8(self, v: i8) -> Result<()> {
         self.parse_state(BYTE_ID)?;
-        self.output.put_i8(v);
+        self.output.extend(v.to_be_bytes());
         Ok(())
     }
 
     fn serialize_i16(self, v: i16) -> Result<()> {
         self.parse_state(SHORT_ID)?;
-        self.output.put_i16(v);
+        self.output.extend(v.to_be_bytes());
         Ok(())
     }
 
     fn serialize_i32(self, v: i32) -> Result<()> {
         self.parse_state(INT_ID)?;
-        self.output.put_i32(v);
+        self.output.extend(v.to_be_bytes());
         Ok(())
     }
 
     fn serialize_i64(self, v: i64) -> Result<()> {
         self.parse_state(LONG_ID)?;
-        self.output.put_i64(v);
+        self.output.extend(v.to_be_bytes());
         Ok(())
     }
 
@@ -157,13 +156,13 @@ impl ser::Serializer for &mut Serializer {
 
     fn serialize_f32(self, v: f32) -> Result<()> {
         self.parse_state(FLOAT_ID)?;
-        self.output.put_f32(v);
+        self.output.extend(v.to_be_bytes());
         Ok(())
     }
 
     fn serialize_f64(self, v: f64) -> Result<()> {
         self.parse_state(DOUBLE_ID)?;
-        self.output.put_f64(v);
+        self.output.extend(v.to_be_bytes());
         Ok(())
     }
 
@@ -179,7 +178,7 @@ impl ser::Serializer for &mut Serializer {
         }
 
         self.output
-            .put(NbtTag::String(v.to_string()).serialize_data());
+            .extend(NbtTag::String(v.to_string()).serialize_data());
         Ok(())
     }
 
@@ -274,7 +273,7 @@ impl ser::Serializer for &mut Serializer {
                     }
                 };
                 self.parse_state(id)?;
-                self.output.put_i32(len.unwrap() as i32);
+                self.output.extend((len.unwrap() as i32).to_be_bytes());
                 self.state = State::ListElement;
             }
             _ => {
@@ -282,8 +281,8 @@ impl ser::Serializer for &mut Serializer {
 
                 // If the list is empty, FirstListElement is never parsed
                 if len.unwrap() == 0 {
-                    self.output.put_u8(END_ID);
-                    self.output.put_i32(0);
+                    self.output.push(END_ID);
+                    self.output.extend(0_i32.to_be_bytes());
                 }
 
                 self.state = State::FirstListElement {
@@ -327,21 +326,21 @@ impl ser::Serializer for &mut Serializer {
             return Ok(self);
         }
 
-        self.output.put_u8(COMPOUND_ID);
+        self.output.push(COMPOUND_ID);
 
         match &mut self.state {
             State::Root(root_name) => {
                 if let Some(root_name) = root_name {
                     self.output
-                        .put(NbtTag::String(root_name.clone()).serialize_data());
+                        .extend(NbtTag::String(root_name.clone()).serialize_data());
                 }
             }
             State::Named(string) => {
                 self.output
-                    .put(NbtTag::String(string.clone()).serialize_data());
+                    .extend(NbtTag::String(string.clone()).serialize_data());
             }
             State::FirstListElement { len } => {
-                self.output.put_i32(*len);
+                self.output.extend(len.to_be_bytes());
             }
             _ => {
                 unimplemented!()
@@ -397,7 +396,7 @@ impl ser::SerializeStruct for &mut Serializer {
     }
 
     fn end(self) -> Result<()> {
-        self.output.put_u8(END_ID);
+        self.output.push(END_ID);
         Ok(())
     }
 }
@@ -422,7 +421,7 @@ impl ser::SerializeMap for &mut Serializer {
     }
 
     fn end(self) -> Result<()> {
-        self.output.put_u8(END_ID);
+        self.output.push(END_ID);
         Ok(())
     }
 }

--- a/src/slice_cursor.rs
+++ b/src/slice_cursor.rs
@@ -1,0 +1,149 @@
+use std::fmt::Debug;
+
+use crate::error::Error;
+
+#[derive(Default, Eq, PartialEq)]
+pub struct BinarySliceCursor<'a> {
+    inner: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> BinarySliceCursor<'a> {
+    /// Creates a new cursor from a binary slice
+    pub fn new(slice: &'a [u8]) -> Self {
+        Self {
+            inner: slice,
+            pos: 0,
+        }
+    }
+
+    /// Sets cursor position
+    pub fn set_pos(&mut self, pos: usize) {
+        self.pos = pos;
+    }
+
+    /// Skips n bytes
+    pub fn skip(&mut self, n: usize) {
+        self.pos += n;
+    }
+
+    pub fn has_remaining(&self) -> bool {
+        self.pos < self.inner.len()
+    }
+
+    /// Reads count bytes as a slice
+    pub fn read(&mut self, count: usize) -> Result<&[u8], Error> {
+        let len = self.inner.len();
+        let end_index = self.pos + count;
+        // end_index is not inclusive
+        if end_index <= len {
+            let slice = &self.inner[self.pos..end_index];
+            self.pos += count;
+            Ok(slice)
+        } else {
+            Err(Error::NotEnoughBytes {
+                requested: count,
+                available: self.inner.len() - self.pos,
+            })
+        }
+    }
+
+    /// Reads N bytes as an array
+    pub fn read_array<const N: usize>(&mut self) -> Result<&[u8; N], Error> {
+        let slice = self.read(N)?;
+        debug_assert_eq!(slice.len(), N);
+        Ok(slice
+            .try_into()
+            .expect("slice should be of the requested length"))
+    }
+
+    /// Reads one byte
+    pub fn read_u8(&mut self) -> Result<u8, Error> {
+        Ok(u8::from_be_bytes(*self.read_array::<1>()?))
+    }
+
+    /// Reads big endian u16
+    pub fn read_u16_be(&mut self) -> Result<u16, Error> {
+        Ok(u16::from_be_bytes(*self.read_array::<2>()?))
+    }
+
+    /// Reads big endian u32
+    pub fn read_u32_be(&mut self) -> Result<u32, Error> {
+        Ok(u32::from_be_bytes(*self.read_array::<4>()?))
+    }
+
+    /// Reads big endian i8
+    pub fn read_i8(&mut self) -> Result<i8, Error> {
+        Ok(i8::from_be_bytes(*self.read_array::<1>()?))
+    }
+
+    /// Reads big endian i16
+    pub fn read_i16_be(&mut self) -> Result<i16, Error> {
+        Ok(i16::from_be_bytes(*self.read_array::<2>()?))
+    }
+
+    /// Reads big endian i32
+    pub fn read_i32_be(&mut self) -> Result<i32, Error> {
+        Ok(i32::from_be_bytes(*self.read_array::<4>()?))
+    }
+
+    /// Reads big endian i64
+    pub fn read_i64_be(&mut self) -> Result<i64, Error> {
+        Ok(i64::from_be_bytes(*self.read_array::<8>()?))
+    }
+
+    /// Reads big endian f32
+    pub fn read_f32_be(&mut self) -> Result<f32, Error> {
+        Ok(f32::from_be_bytes(*self.read_array::<4>()?))
+    }
+
+    /// Reads big endian f64
+    pub fn read_f64_be(&mut self) -> Result<f64, Error> {
+        Ok(f64::from_be_bytes(*self.read_array::<8>()?))
+    }
+}
+
+impl<'a> AsRef<BinarySliceCursor<'a>> for BinarySliceCursor<'a> {
+    fn as_ref(&self) -> &BinarySliceCursor<'a> {
+        self
+    }
+}
+
+impl<'a> AsMut<BinarySliceCursor<'a>> for BinarySliceCursor<'a> {
+    fn as_mut(&mut self) -> &mut BinarySliceCursor<'a> {
+        self
+    }
+}
+
+impl<'a> Debug for BinarySliceCursor<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BinarySliceCursor")
+            .field("pos", &self.pos)
+            .field(
+                "inner",
+                &format_args!("slice of length {}", self.inner.len()),
+            )
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{error::Error, slice_cursor::BinarySliceCursor};
+
+    #[test]
+    fn test_get_slice() {
+        let mut cursor = BinarySliceCursor::new(&[0, 1, 2, 3, 4, 5, 6][..]);
+        cursor.set_pos(2);
+        let slice = cursor.read(3).unwrap();
+        assert_eq!(slice, &[2, 3, 4][..]);
+        let slice2 = cursor.read(10).unwrap_err();
+        assert!(matches!(
+            slice2,
+            Error::NotEnoughBytes {
+                available: 2,
+                requested: 10
+            }
+        ));
+    }
+}

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1,4 +1,3 @@
-use bytes::Bytes;
 use crab_nbt::{nbt, Nbt, NbtCompound, NbtTag};
 
 #[test]
@@ -44,7 +43,7 @@ fn nbt_macro_panics_on_nonexistent_key() {
 #[test]
 fn nbt_macro_complex_object() {
     let key = "a_key".to_owned();
-    let some_bytes = Bytes::from_iter([0, 1, 2, 3]);
+    let some_bytes = Vec::from_iter([0, 1, 2, 3]);
 
     let nbt_expected = Nbt::new(
         "root".to_owned(),

--- a/tests/serde/basic.rs
+++ b/tests/serde/basic.rs
@@ -1,4 +1,3 @@
-use bytes::BytesMut;
 use crab_nbt::serde::arrays::IntArray;
 use crab_nbt::serde::bool::deserialize_option_bool;
 use crab_nbt::serde::de::from_bytes_unnamed;
@@ -54,7 +53,7 @@ fn test_serialize() {
 
 #[test]
 fn test_deserialize() {
-    let mut test = BytesMut::from(
+    let mut test = Vec::from(
         &nbt!("", {
             "str": "hi ❤️",
             "boolean": false,

--- a/tests/serde/bigtest.rs
+++ b/tests/serde/bigtest.rs
@@ -1,5 +1,4 @@
 use crate::serde::test_data_definitions::BigTest;
-use bytes::BytesMut;
 use crab_nbt::serde::{
     de::{from_bytes, from_bytes_unnamed},
     ser::{to_bytes, to_bytes_unnamed},
@@ -8,7 +7,7 @@ use std::mem;
 
 #[test]
 fn test_roundtrip_bigtest() {
-    let bytes = BytesMut::from(include_bytes!("../data/bigtest.nbt") as &[u8]);
+    let bytes = Vec::from(include_bytes!("../data/bigtest.nbt") as &[u8]);
     let deserialized = from_bytes::<BigTest>(&mut bytes.clone()).unwrap();
     let bytes2 = to_bytes(&deserialized, "Level".to_string()).unwrap();
     let deserialized2 = from_bytes::<BigTest>(&mut bytes2.clone()).unwrap();
@@ -19,7 +18,7 @@ fn test_roundtrip_bigtest() {
 
 #[test]
 fn test_roundtrip_bigtest_unnamed() {
-    let bytes = BytesMut::from(include_bytes!("../data/bigtest.nbt") as &[u8]);
+    let bytes = Vec::from(include_bytes!("../data/bigtest.nbt") as &[u8]);
     let deserialized = from_bytes::<BigTest>(&mut bytes.clone()).unwrap();
     let bytes2 = to_bytes_unnamed(&deserialized).unwrap();
     let deserialized2 = from_bytes_unnamed::<BigTest>(&mut bytes2.clone()).unwrap();

--- a/tests/serde/complex.rs
+++ b/tests/serde/complex.rs
@@ -1,5 +1,4 @@
 use crate::{serde::test_data_definitions::ComplexPlayer, util::decompress_data};
-use bytes::BytesMut;
 use crab_nbt::serde::{
     de::{from_bytes, from_bytes_unnamed},
     ser::{to_bytes, to_bytes_unnamed},
@@ -7,9 +6,7 @@ use crab_nbt::serde::{
 
 #[test]
 fn test_roundtrip_complex() {
-    let bytes = BytesMut::from_iter(decompress_data(
-        include_bytes!("../data/complex_player.dat") as &[u8],
-    ));
+    let bytes = decompress_data(include_bytes!("../data/complex_player.dat") as &[u8]);
     let deserialized = from_bytes::<ComplexPlayer>(&mut bytes.clone()).unwrap();
     let bytes2 = to_bytes(&deserialized, "".to_owned()).unwrap();
     let deserialized2 = from_bytes::<ComplexPlayer>(&mut bytes2.clone()).unwrap();
@@ -20,9 +17,7 @@ fn test_roundtrip_complex() {
 
 #[test]
 fn test_roundtrip_complex_unnamed() {
-    let bytes = BytesMut::from_iter(decompress_data(
-        include_bytes!("../data/complex_player.dat") as &[u8],
-    ));
+    let bytes = decompress_data(include_bytes!("../data/complex_player.dat") as &[u8]);
     let deserialized = from_bytes::<ComplexPlayer>(&mut bytes.clone()).unwrap();
     let bytes2 = to_bytes_unnamed(&deserialized).unwrap();
     let deserialized2 = from_bytes_unnamed::<ComplexPlayer>(&mut bytes2.clone()).unwrap();

--- a/tests/serde/unit_variant.rs
+++ b/tests/serde/unit_variant.rs
@@ -13,7 +13,7 @@ fn test_enum_unit_variant() {
     let test = Event::OpenUrl("test".to_string().into());
     let bytes = to_bytes_unnamed(&test).unwrap();
     assert_eq!(
-        bytes.as_ref(),
+        &bytes[..],
         b"\n\x08\0\x06action\0\x08open_url\x08\0\x05value\0\x04test\0"
     );
 }

--- a/tests/tag.rs
+++ b/tests/tag.rs
@@ -1,4 +1,3 @@
-use bytes::Bytes;
 use crab_nbt::{nbt, Nbt, NbtTag};
 
 #[test]
@@ -16,8 +15,8 @@ fn serialize_data() {
 
 #[test]
 fn deserialize_bigtest() {
-    let bytes = Bytes::from(include_bytes!("data/bigtest.nbt") as &[u8]);
-    let nbt = Nbt::read(&mut bytes.clone()).unwrap();
+    let bytes = Vec::from(include_bytes!("data/bigtest.nbt") as &[u8]);
+    let nbt = Nbt::read(&bytes[..]).unwrap();
     let egg_name = nbt
         .get_compound("nested compound test")
         .and_then(|compound| compound.get_compound("egg"))
@@ -38,7 +37,7 @@ fn network_nbt() {
 
     let bytes = expected_nbt.write_unnamed();
 
-    let nbt = Nbt::read_unnamed(&mut bytes.clone()).unwrap();
+    let nbt = Nbt::read_unnamed(&bytes[..]).unwrap();
 
     assert_eq!(nbt, expected_nbt);
 }
@@ -50,7 +49,7 @@ fn correct_end_tags() {
     });
 
     let expected: &[u8] = b"\n\x0c\0\rWORLD_SURFACE\0\0\0\0\0";
-    assert_eq!(heightmap.write_unnamed().as_ref(), expected)
+    assert_eq!(&heightmap.write_unnamed()[..], expected)
 }
 
 #[test]
@@ -70,7 +69,7 @@ fn nested_tag_compounds() {
 
     let bytes = original_nbt.write_unnamed();
 
-    let deserialized_nbt = Nbt::read_unnamed(&mut bytes.clone()).unwrap();
+    let deserialized_nbt = Nbt::read_unnamed(&bytes[..]).unwrap();
 
     assert_eq!(deserialized_nbt, original_nbt);
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,6 +1,5 @@
 use std::{fs, io::Read};
 
-use bytes::Bytes;
 use flate2::bufread::GzDecoder;
 
 #[allow(unused)]
@@ -15,11 +14,11 @@ pub fn decompress_data(buffer: &[u8]) -> Vec<u8> {
 }
 
 #[allow(unused)]
-pub fn read_file(file_path: &str, compressed: bool) -> Bytes {
-    let data = &fs::read(file_path).expect("Failed to open file")[..];
+pub fn read_file(file_path: &str, compressed: bool) -> Vec<u8> {
+    let data = fs::read(file_path).expect("Failed to open file");
     if compressed {
-        Bytes::from_iter(decompress_data(data))
+        decompress_data(&data[..])
     } else {
-        Bytes::from_iter(data.iter().copied())
+        data
     }
 }


### PR DESCRIPTION
Removes our dependency on the `bytes` crate.
Instead we use our own `BinarySliceCursor` type, which acts as a wrapper over `&[u8]`.
The type also has checks for how many bytes are remaining which means this closes #26
For writing we now use a raw Vec<u8>, with `.extend(num.to_be_bytes())`. I considered also creating a wrapper type, however I belive it is unnecesary and would be mostly a boilerplate.

As a side effect of these changes we also got some pretty nice performance improvements, especially on the write side, which was pretty unexpected to me.

Question - do we want to keep the cursor methods? They were originally added as a way to avoid `bytes` which is now not needed.

