### PR TITLE
Add SNBT serialisation

### DIFF
--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -3,7 +3,7 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crab_nbt::nbt::compound::NbtCompound;
 use crab_nbt::nbt::tag::NbtTag;
 use crab_nbt::nbt::utils::*;
-use std::fmt::{Display, Formatter};
+use std::fmt::{self, Display, Formatter};
 use std::io::{Cursor, Write};
 use std::ops::Deref;
 
@@ -122,7 +122,7 @@ impl AsMut<NbtCompound> for Nbt {
 }
 
 impl Display for Nbt {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{{\"{}\": {}}}", self.name, self.root_tag)
     }
 }

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -3,7 +3,7 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crab_nbt::nbt::compound::NbtCompound;
 use crab_nbt::nbt::tag::NbtTag;
 use crab_nbt::nbt::utils::*;
-use std::fmt::Display;
+use std::fmt::{Display, Formatter};
 use std::io::{Cursor, Write};
 use std::ops::Deref;
 
@@ -122,7 +122,7 @@ impl AsMut<NbtCompound> for Nbt {
 }
 
 impl Display for Nbt {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{{\"{}\": {}}}", self.name, self.root_tag)
     }
 }

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -3,6 +3,7 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crab_nbt::nbt::compound::NbtCompound;
 use crab_nbt::nbt::tag::NbtTag;
 use crab_nbt::nbt::utils::*;
+use std::fmt::Display;
 use std::io::{Cursor, Write};
 use std::ops::Deref;
 
@@ -117,5 +118,11 @@ where
 impl AsMut<NbtCompound> for Nbt {
     fn as_mut(&mut self) -> &mut NbtCompound {
         &mut self.root_tag
+    }
+}
+
+impl Display for Nbt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{\"{}\": {}}}", self.name, self.root_tag)
     }
 }

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -1,8 +1,10 @@
+use crate::nbt::utils::{escape_name, join_formatted};
 use crate::{error::Error, Nbt};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crab_nbt::nbt::tag::NbtTag;
 use crab_nbt::nbt::utils::{get_nbt_string, END_ID};
 use derive_more::Into;
+use std::fmt::{Debug, Display};
 use std::io::{Cursor, Write};
 use std::vec::IntoIter;
 
@@ -161,5 +163,21 @@ impl Extend<(String, NbtTag)> for NbtCompound {
 impl AsRef<NbtCompound> for NbtCompound {
     fn as_ref(&self) -> &NbtCompound {
         self
+    }
+}
+
+impl Display for NbtCompound {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{")?;
+        
+        let iterator = (&self.child_tags).into_iter().peekable()
+            .map(|(name, tag)| {
+                move |f: &mut std::fmt::Formatter<'_>| {
+                    write!(f, "{}: {tag}", escape_name(name))
+                }
+            });
+        join_formatted(f, ", ", iterator)?;
+
+        write!(f, "}}")
     }
 }

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -170,7 +170,7 @@ impl Display for NbtCompound {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{{")?;
         
-        let iterator = (&self.child_tags).into_iter().peekable()
+        let iterator = (&self.child_tags).iter().peekable()
             .map(|(name, tag)| {
                 move |f: &mut Formatter<'_>| {
                     write!(f, "{}: {tag}", escape_name(name))

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -4,7 +4,7 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crab_nbt::nbt::tag::NbtTag;
 use crab_nbt::nbt::utils::{get_nbt_string, END_ID};
 use derive_more::Into;
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 use std::io::{Cursor, Write};
 use std::vec::IntoIter;
 
@@ -167,7 +167,7 @@ impl AsRef<NbtCompound> for NbtCompound {
 }
 
 impl Display for NbtCompound {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{{")?;
         
         let iterator = (&self.child_tags).iter().peekable()

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -169,13 +169,10 @@ impl AsRef<NbtCompound> for NbtCompound {
 impl Display for NbtCompound {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{{")?;
-        
-        let iterator = (&self.child_tags).iter().peekable()
-            .map(|(name, tag)| {
-                move |f: &mut Formatter<'_>| {
-                    write!(f, "{}: {tag}", escape_name(name))
-                }
-            });
+
+        let iterator = self.child_tags.iter().map(|(name, tag)| {
+            move |f: &mut Formatter<'_>| write!(f, "{}: {tag}", escape_name(name))
+        });
         join_formatted(f, ", ", iterator)?;
 
         write!(f, "}}")

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -4,7 +4,7 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crab_nbt::nbt::tag::NbtTag;
 use crab_nbt::nbt::utils::{get_nbt_string, END_ID};
 use derive_more::Into;
-use std::fmt::{Debug, Display};
+use std::fmt::{Debug, Display, Formatter};
 use std::io::{Cursor, Write};
 use std::vec::IntoIter;
 
@@ -167,12 +167,12 @@ impl AsRef<NbtCompound> for NbtCompound {
 }
 
 impl Display for NbtCompound {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{{")?;
         
         let iterator = (&self.child_tags).into_iter().peekable()
             .map(|(name, tag)| {
-                move |f: &mut std::fmt::Formatter<'_>| {
+                move |f: &mut Formatter<'_>| {
                     write!(f, "{}: {tag}", escape_name(name))
                 }
             });

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -276,7 +276,7 @@ impl From<bool> for NbtTag {
 }
 
 impl Display for NbtTag {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::End => Ok(()),
             Self::Byte(x) => write!(f, "{x}b"),
@@ -301,7 +301,7 @@ impl Display for NbtTag {
 
 fn write_listlike<T: Display, I: IntoIterator<Item = T>>
     (f: &mut Formatter<'_>, prefix: &'static str, affix: &'static str, arr: I)
-    -> std::fmt::Result {
+    -> fmt::Result {
     write!(f, "[{prefix}")?;
     join_formatted(
         f, ", ",

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -3,7 +3,7 @@ use crab_nbt::error::Error;
 use crab_nbt::nbt::compound::NbtCompound;
 use crab_nbt::nbt::utils::*;
 use derive_more::From;
-use std::fmt::{Display, Formatter};
+use std::fmt::{self, Display, Formatter};
 use std::io::Cursor;
 
 /// Enum representing the different types of NBT tags.

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -286,26 +286,28 @@ impl Display for NbtTag {
             // using debug here matches Minecraft on whole numbers (3.0 instead of 3)
             Self::Float(x) => write!(f, "{x:?}f"),
             Self::Double(x) => write!(f, "{x:?}d"),
-            Self::ByteArray(arr) => write_listlike(
-                f, "B; ", "B",
-                arr.iter().map(|b| *b as i8)
-            ),
+            Self::ByteArray(arr) => write_listlike(f, "B; ", "B", arr.iter().map(|b| *b as i8)),
             Self::String(s) => write!(f, "{}", escape_string_value(s)),
             Self::List(list) => write_listlike(f, "", "", list),
             Self::Compound(compound) => write!(f, "{compound}"),
             Self::IntArray(arr) => write_listlike(f, "I; ", "", arr),
-            Self::LongArray(arr) => write_listlike(f, "L; ", "L", arr)
+            Self::LongArray(arr) => write_listlike(f, "L; ", "L", arr),
         }
     }
 }
 
-fn write_listlike<T: Display, I: IntoIterator<Item = T>>
-    (f: &mut Formatter<'_>, prefix: &'static str, affix: &'static str, arr: I)
-    -> fmt::Result {
+fn write_listlike<T: Display, I: IntoIterator<Item = T>>(
+    f: &mut Formatter<'_>,
+    prefix: &'static str,
+    affix: &'static str,
+    arr: I,
+) -> fmt::Result {
     write!(f, "[{prefix}")?;
     join_formatted(
-        f, ", ",
-        arr.into_iter().map(|x| move |f: &mut Formatter<'_>| write!(f, "{x}{affix}"))
+        f,
+        ", ",
+        arr.into_iter()
+            .map(|x| move |f: &mut Formatter<'_>| write!(f, "{x}{affix}")),
     )?;
     write!(f, "]")
 }

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -283,8 +283,9 @@ impl Display for NbtTag {
             Self::Short(x) => write!(f, "{x}s"),
             Self::Int(x) => write!(f, "{x}"),
             Self::Long(x) => write!(f, "{x}L"),
-            Self::Float(x) => write!(f, "{x}f"),
-            Self::Double(x) => write!(f, "{x}d"),
+            // using debug here matches Minecraft on whole numbers (3.0 instead of 3)
+            Self::Float(x) => write!(f, "{x:?}f"),
+            Self::Double(x) => write!(f, "{x:?}d"),
             Self::ByteArray(arr) => write_listlike(
                 f, "B; ", "B",
                 arr.iter().map(|b| *b as i8)

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -63,12 +63,10 @@ pub(crate) fn join_formatted<Separator, I, F>
     Ok(())
 }
 
-pub(crate) fn escape_name(s: &String) -> String {
-    // This is not quite perfect, given that it always iterates s twice
-    // I would wish for a better solution, but it would be quite complicated
+pub(crate) fn escape_name(s: &str) -> String {
     let may_be_unquoted = !s.is_empty() && s.chars()
         .all(|c| c.is_alphanumeric() || c == '.' || c == '_' || c == '+' || c == '-' );
-    if may_be_unquoted { s.clone() } 
+    if may_be_unquoted { s.to_owned() } 
     else { escape_string_value(s) }
 }
 

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Display, Formatter};
+use std::fmt::{self, Display, Formatter};
 
 use crate::error::Error;
 use bytes::Buf;

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -71,26 +71,25 @@ pub(crate) fn escape_name(s: &str) -> String {
 }
 
 pub(crate) fn escape_string_value(s: &str) -> String {
-    let mut output = String::with_capacity(s.as_bytes().len() + 2); // +2 because ""
-    // using str here is a bit weird, but it is the best way to allow use of String::replace_range
-    let mut escape_char = None;
-    output.push('"');
+    let mut output = String::with_capacity(s.len() + 2); // +2 because ""
+    let mut chosen_quote = None;
+    output.push('"');  // placeholder character until we know what quote to use
     for c in s.chars() {
         if c == '\\' {
             output.push('\\');
         } else if c == '"' || c == '\'' {
-            if escape_char.is_none() {
-                escape_char = Some(if c == '"' { "\'" } else { "\"" });
+            if chosen_quote.is_none() {
+                chosen_quote = Some(if c == '"' { '\'' } else { '"' });
             }
-            if escape_char.map(|d| d.starts_with(c)).unwrap_or(false) {
+            if chosen_quote.map(|q| q == c).unwrap_or(false) {
                 output.push('\\');
             }
         }
         output.push(c);
     }
 
-    let escape_char = escape_char.unwrap_or("\"");
-    output.replace_range(0..1, escape_char);
-    output.push_str(escape_char);
+    let escape_char = chosen_quote.unwrap_or('\"');
+    output.replace_range(0..1, &escape_char.to_string());
+    output.push(escape_char);
     output
 }

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -48,10 +48,10 @@ where
 /// like [T]::join, but allowing for formatting
 /// Runs a sequence of formatting functions, interspersed with instances of `separator`
 pub(crate) fn join_formatted<Separator, I, F>
-    (f: &mut Formatter<'_>, separator: Separator, iterator: I) -> std::fmt::Result 
+    (f: &mut Formatter<'_>, separator: Separator, iterator: I) -> fmt::Result 
     where Separator: Clone + Display, 
             I: IntoIterator<Item = F>, 
-            F: FnOnce(&mut Formatter<'_>) -> std::fmt::Result,
+            F: FnOnce(&mut Formatter<'_>) -> fmt::Result,
 {
     let mut peekable = iterator.into_iter().peekable();
     while let Some(function) = peekable.next() {

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -47,11 +47,15 @@ where
 
 /// like [T]::join, but allowing for formatting
 /// Runs a sequence of formatting functions, interspersed with instances of `separator`
-pub(crate) fn join_formatted<Separator, I, F>
-    (f: &mut Formatter<'_>, separator: Separator, iterator: I) -> fmt::Result 
-    where Separator: Clone + Display, 
-            I: IntoIterator<Item = F>, 
-            F: FnOnce(&mut Formatter<'_>) -> fmt::Result,
+pub(crate) fn join_formatted<Separator, I, F>(
+    f: &mut Formatter<'_>,
+    separator: Separator,
+    iterator: I,
+) -> fmt::Result
+where
+    Separator: Clone + Display,
+    I: IntoIterator<Item = F>,
+    F: FnOnce(&mut Formatter<'_>) -> fmt::Result,
 {
     let mut peekable = iterator.into_iter().peekable();
     while let Some(function) = peekable.next() {
@@ -64,16 +68,20 @@ pub(crate) fn join_formatted<Separator, I, F>
 }
 
 pub(crate) fn escape_name(s: &str) -> String {
-    let may_be_unquoted = !s.is_empty() && s.chars()
-        .all(|c| c.is_alphanumeric() || c == '.' || c == '_' || c == '+' || c == '-' );
-    if may_be_unquoted { s.to_owned() } 
-    else { escape_string_value(s) }
+    let may_be_unquoted = !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_alphanumeric() || c == '.' || c == '_' || c == '+' || c == '-');
+    if may_be_unquoted {
+        s.to_owned()
+    } else {
+        escape_string_value(s)
+    }
 }
 
 pub(crate) fn escape_string_value(s: &str) -> String {
     let mut output = String::with_capacity(s.len() + 2); // +2 because ""
     let mut chosen_quote = None;
-    output.push('"');  // placeholder character until we know what quote to use
+    output.push('"'); // placeholder character until we know what quote to use
     for c in s.chars() {
         if c == '\\' {
             output.push('\\');
@@ -115,7 +123,10 @@ mod tests {
 
     #[test]
     fn escape_name_single_quotes() {
-        assert_eq!(escape_name("ineed\"special\"handling"), "'ineed\"special\"handling'");
+        assert_eq!(
+            escape_name("ineed\"special\"handling"),
+            "'ineed\"special\"handling'"
+        );
         assert_eq!(escape_name("double\"single'"), "'double\"single\\''")
     }
 }

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -45,8 +45,8 @@ where
         .collect()
 }
 
-// like [T]::join, but allowing for formatting
-// Runs a sequence of formatting functions, interspersed with instances of `separator`
+/// like [T]::join, but allowing for formatting
+/// Runs a sequence of formatting functions, interspersed with instances of `separator`
 pub(crate) fn join_formatted<Separator, I, F>
     (f: &mut Formatter<'_>, separator: Separator, iterator: I) -> std::fmt::Result 
     where Separator: Clone + Display, 
@@ -92,4 +92,30 @@ pub(crate) fn escape_string_value(s: &str) -> String {
     output.replace_range(0..1, &escape_char.to_string());
     output.push(escape_char);
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_name_no_quotes() {
+        assert_eq!(escape_name("hello1234"), "hello1234");
+        assert_eq!(escape_name("1234_hello__..WORLD"), "1234_hello__..WORLD");
+        assert_eq!(escape_name("...boo"), "...boo");
+    }
+
+    #[test]
+    fn escape_name_normal_quotes() {
+        assert_eq!(escape_name("minecraft:damage"), "\"minecraft:damage\"");
+        assert_eq!(escape_name("i haveaspace"), "\"i haveaspace\"");
+        assert_eq!(escape_name("i have many spaces"), "\"i have many spaces\"");
+        assert_eq!(escape_name("single'double\""), "\"single'double\\\"\"");
+    }
+
+    #[test]
+    fn escape_name_single_quotes() {
+        assert_eq!(escape_name("ineed\"special\"handling"), "'ineed\"special\"handling'");
+        assert_eq!(escape_name("double\"single'"), "'double\"single\\''")
+    }
 }

--- a/src/serde/nbt_types.rs
+++ b/src/serde/nbt_types.rs
@@ -63,7 +63,7 @@ impl<'de> Deserialize<'de> for NbtTag {
         impl<'de> serde::de::Visitor<'de> for NbtTagVisitor {
             type Value = NbtTag;
 
-            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
                 formatter.write_str("an NBT tag")
             }
 
@@ -151,7 +151,7 @@ impl<'de> Deserialize<'de> for NbtCompound {
         impl<'de> serde::de::Visitor<'de> for NbtCompoundVisitor {
             type Value = NbtCompound;
 
-            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
                 formatter.write_str("an NBT compound")
             }
 

--- a/src/serde/nbt_types.rs
+++ b/src/serde/nbt_types.rs
@@ -63,7 +63,7 @@ impl<'de> Deserialize<'de> for NbtTag {
         impl<'de> serde::de::Visitor<'de> for NbtTagVisitor {
             type Value = NbtTag;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
                 formatter.write_str("an NBT tag")
             }
 
@@ -151,7 +151,7 @@ impl<'de> Deserialize<'de> for NbtCompound {
         impl<'de> serde::de::Visitor<'de> for NbtCompoundVisitor {
             type Value = NbtCompound;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
                 formatter.write_str("an NBT compound")
             }
 

--- a/src/serde/nbt_types.rs
+++ b/src/serde/nbt_types.rs
@@ -63,7 +63,7 @@ impl<'de> Deserialize<'de> for NbtTag {
         impl<'de> serde::de::Visitor<'de> for NbtTagVisitor {
             type Value = NbtTag;
 
-            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("an NBT tag")
             }
 
@@ -151,7 +151,7 @@ impl<'de> Deserialize<'de> for NbtCompound {
         impl<'de> serde::de::Visitor<'de> for NbtCompoundVisitor {
             type Value = NbtCompound;
 
-            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("an NBT compound")
             }
 

--- a/tests/snbt.rs
+++ b/tests/snbt.rs
@@ -1,6 +1,5 @@
 use bytes::Bytes;
-use crab_nbt::{NbtTag, nbt};
-
+use crab_nbt::{nbt, NbtTag};
 
 #[test]
 fn compound_with_basic_numbers() {

--- a/tests/snbt.rs
+++ b/tests/snbt.rs
@@ -4,8 +4,8 @@ use crab_nbt::{/*nbt::tag::escape_string_value,*/ NbtTag, nbt};
 
 #[test]
 fn compound_with_basic_numbers() {
-    let test_string = "{\"\": {a: 0b, b: 1s, c: 2, d: 3L}}";
-    let nbt = nbt!("", {"a": 0i8, "b": 1i16, "c": 2i32, "d": 3i64});
+    let test_string = "{\"\": {a: 0b, b: 1s, c: 2, d: 3L, e: 1.0f, f: 1.5f, g: 2.0d, h: 3.14d}}";
+    let nbt = nbt!("", {"a": 0i8, "b": 1i16, "c": 2i32, "d": 3i64, "e": 1.0f32, "f": 1.5f32, "g": 2.0f64, "h": 3.14f64});
     assert_eq!(nbt.to_string(), test_string)
 }
 
@@ -32,11 +32,27 @@ fn long_array() {
 
 #[test]
 fn complex_compound() {
-    let test_string = "{\"\": {components: {\"minecraft:unbreakable\": {}, \"minecraft:custom_name\": '\"Excalibur\"', \"minecraft:rarity\": \"rare\"}, count: 1, id: \"minecraft:iron_sword\"}}";
+    let test_string = "{\"\": {components: {\"minecraft:attribute_modifiers\": [{amount: 1.5d, id: \"example:grow\", slot: \"hand\", type: \"minecraft:scale\", operation: \"add_multiplied_base\"}, {amount: 4.0d, id: \"example:attack\", slot: \"hand\", type: \"minecraft:attack_damage\", operation: \"add_multiplied_base\"}], \"minecraft:unbreakable\": {}, \"minecraft:custom_name\": \"Excalibur\", \"minecraft:rarity\": \"rare\"}, count: 1, id: \"minecraft:iron_sword\"}}";
     let nbt = nbt!("", {
         "components": {
+            "minecraft:attribute_modifiers": [
+                {
+                    "amount": 1.5,
+                    "id": "example:grow",
+                    "slot": "hand",
+                    "type": "minecraft:scale",
+                    "operation": "add_multiplied_base"
+                },
+                {
+                    "amount": 4.0,
+                    "id": "example:attack",
+                    "slot": "hand",
+                    "type": "minecraft:attack_damage",
+                    "operation": "add_multiplied_base"
+                }
+            ],
             "minecraft:unbreakable": {},
-            "minecraft:custom_name": "\"Excalibur\"",
+            "minecraft:custom_name": "Excalibur",
             "minecraft:rarity": "rare"
         },
         "count": 1,

--- a/tests/snbt.rs
+++ b/tests/snbt.rs
@@ -1,0 +1,54 @@
+use bytes::Bytes;
+use crab_nbt::{/*nbt::tag::escape_string_value,*/ NbtTag, nbt};
+
+
+#[test]
+fn compound_with_basic_numbers() {
+    let test_string = "{\"\": {a: 0b, b: 1s, c: 2, d: 3L}}";
+    let nbt = nbt!("", {"a": 0i8, "b": 1i16, "c": 2i32, "d": 3i64});
+    assert_eq!(nbt.to_string(), test_string)
+}
+
+#[test]
+fn byte_array() {
+    let test_string = "[B; 45B, -37B, 111B, -90B]";
+    let nbt = NbtTag::ByteArray(Bytes::from(vec![45, 219, 111, 166]));
+    assert_eq!(nbt.to_string(), test_string)
+}
+
+#[test]
+fn int_array() {
+    let test_string = "[I; 1906, -165, -1073741824]";
+    let nbt = NbtTag::IntArray(vec![1906, -165, -1073741824]);
+    assert_eq!(nbt.to_string(), test_string)
+}
+
+#[test]
+fn long_array() {
+    let test_string = "[L; 1906L, -165L, -1073741824L, 576460752303423488L]";
+    let nbt = NbtTag::LongArray(vec![1906, -165, -1073741824, 576460752303423488]);
+    assert_eq!(nbt.to_string(), test_string)
+}
+
+#[test]
+fn complex_compound() {
+    let test_string = "{\"\": {components: {\"minecraft:unbreakable\": {}, \"minecraft:custom_name\": '\"Excalibur\"', \"minecraft:rarity\": \"rare\"}, count: 1, id: \"minecraft:iron_sword\"}}";
+    let nbt = nbt!("", {
+        "components": {
+            "minecraft:unbreakable": {},
+            "minecraft:custom_name": "\"Excalibur\"",
+            "minecraft:rarity": "rare"
+        },
+        "count": 1,
+        "id": "minecraft:iron_sword"
+    });
+    assert_eq!(nbt.to_string(), test_string)
+}
+
+// #[test]
+// fn string_escape() {
+//     assert_eq!(escape_string_value("minecraft:grass_block"), "\"minecraft:grass_block\"");
+//     assert_eq!(escape_string_value("\"I am a JSON string!\""), "\'\"I am a JSON string!\"\'");
+//     assert_eq!(escape_string_value("I am very normal"), "\"I am very normal\"");
+//     assert_eq!(escape_string_value("Idontevenhavespaces"), "\"Idontevenhavespaces\"");
+// }

--- a/tests/snbt.rs
+++ b/tests/snbt.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use crab_nbt::{/*nbt::tag::escape_string_value,*/ NbtTag, nbt};
+use crab_nbt::{NbtTag, nbt};
 
 
 #[test]
@@ -60,11 +60,3 @@ fn complex_compound() {
     });
     assert_eq!(nbt.to_string(), test_string)
 }
-
-// #[test]
-// fn string_escape() {
-//     assert_eq!(escape_string_value("minecraft:grass_block"), "\"minecraft:grass_block\"");
-//     assert_eq!(escape_string_value("\"I am a JSON string!\""), "\'\"I am a JSON string!\"\'");
-//     assert_eq!(escape_string_value("I am very normal"), "\"I am very normal\"");
-//     assert_eq!(escape_string_value("Idontevenhavespaces"), "\"Idontevenhavespaces\"");
-// }


### PR DESCRIPTION
Currently, the various Nbt types only implement `std::fmt::Debug`, which displays the internal structure and is very hard to read. A more readable format (for non-debugging purposes) would be to format the data as SNBT, completing one half of #32 in so doing.

As such, I have implemented `std::fmt::Display` on `Nbt`, `NbtTag`, and `NbtCompound`, which produces valid SNBT matching the formatting used by Minecraft. I have also added various unit tests that match, again, the output produced by CrabNBT with real Minecraft SNBT output.

Following the SNBT standard ensures a lossless representation of the data, moreover one that is easily machine parsable. This opens up the possibility of implementing `std::str::FromStr` in the future, which would also handily complete the other side of #32.