### PR TITLE
perf: reuse allocations where possible for refactor/remove-bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = ["dep:serde"]
 nightly = ["simd_cesu8/nightly"]
 
 [dependencies]
-simd_cesu8 = "1.0.1"
+simd_cesu8 = "1.2.0"
 derive_more = { version = "2.0.1", features = ["into", "from"] }
 thiserror = "2.0.11"
 serde = { version = "1.0.218", optional = true, features = ["derive"] }

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -90,8 +90,7 @@ impl Nbt {
     /// Used in [Network NBT](https://wiki.vg/NBT#Network_NBT_(Java_Edition)).
     pub fn write_unnamed(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
-        bytes.push(COMPOUND_ID);
-        self.root_tag.serialize_content_into(&mut bytes);
+        self.write_unnamed_into(&mut bytes);
         bytes
     }
 

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -72,8 +72,8 @@ impl Nbt {
     pub fn write(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
         bytes.push(COMPOUND_ID);
-        bytes.extend(NbtTag::String(self.name.to_string()).serialize_data());
-        bytes.extend(self.root_tag.serialize_content());
+        NbtTag::String(self.name.to_string()).serialize_data_into(&mut bytes);
+        self.root_tag.serialize_content_into(&mut bytes);
         bytes
     }
 
@@ -87,7 +87,7 @@ impl Nbt {
     pub fn write_unnamed(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
         bytes.push(COMPOUND_ID);
-        bytes.extend(self.root_tag.serialize_content());
+        self.root_tag.serialize_content_into(&mut bytes);
         bytes
     }
 

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -71,10 +71,14 @@ impl Nbt {
 
     pub fn write(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
-        bytes.push(COMPOUND_ID);
-        NbtTag::String(self.name.to_string()).serialize_data_into(&mut bytes);
-        self.root_tag.serialize_content_into(&mut bytes);
+        self.write_into(&mut bytes);
         bytes
+    }
+
+    pub fn write_into(&self, bytes: &mut Vec<u8>) {
+        bytes.push(COMPOUND_ID);
+        NbtTag::serialize_str_into(&self.name, bytes);
+        self.root_tag.serialize_content_into(bytes);
     }
 
     pub fn write_to_writer<W: Write>(&self, mut writer: W) -> Result<(), Error> {
@@ -89,6 +93,11 @@ impl Nbt {
         bytes.push(COMPOUND_ID);
         self.root_tag.serialize_content_into(&mut bytes);
         bytes
+    }
+
+    pub fn write_unnamed_into(&self, bytes: &mut Vec<u8>) {
+        bytes.push(COMPOUND_ID);
+        self.root_tag.serialize_content_into(bytes);
     }
 
     pub fn write_unnamed_to_writer<W: Write>(&self, mut writer: W) -> Result<(), Error> {

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -76,6 +76,7 @@ impl Nbt {
     }
 
     pub fn write_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(1 + 2 + self.name.len() + self.root_tag.size_hint().0);
         bytes.push(COMPOUND_ID);
         NbtTag::serialize_str_into(&self.name, bytes);
         self.root_tag.serialize_content_into(bytes);
@@ -95,6 +96,7 @@ impl Nbt {
     }
 
     pub fn write_unnamed_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(1 + self.root_tag.size_hint().0);
         bytes.push(COMPOUND_ID);
         self.root_tag.serialize_content_into(bytes);
     }

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -65,6 +65,16 @@ impl NbtCompound {
         bytes.push(END_ID);
     }
 
+    pub fn size_hint(&self) -> (usize, usize) {
+        self.child_tags
+            .iter()
+            .map(|(s, t)| {
+                let hint = NbtTag::size_hint(t);
+                (1 + 2 + s.len() + hint.0, 1 + 2 + s.len() * 2 + hint.1)
+            })
+            .fold((1, 1), |a, b| (a.0 + b.0, a.1 + b.1))
+    }
+
     pub fn serialize_content_to_writer<W: Write>(&self, mut writer: W) -> Result<(), Error> {
         writer.write_all(&self.serialize_content())?;
         Ok(())

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -52,13 +52,17 @@ impl NbtCompound {
 
     pub fn serialize_content(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
+        self.serialize_content_into(&mut bytes);
+        bytes
+    }
+
+    pub fn serialize_content_into(&self, bytes: &mut Vec<u8>) {
         for (name, tag) in &self.child_tags {
             bytes.push(tag.get_type_id());
-            bytes.extend(NbtTag::String(name.clone()).serialize_data());
-            bytes.extend(tag.serialize_data());
+            NbtTag::serialize_str_into(name, bytes);
+            tag.serialize_data_into(bytes);
         }
         bytes.push(END_ID);
-        bytes
     }
 
     pub fn serialize_content_to_writer<W: Write>(&self, mut writer: W) -> Result<(), Error> {

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -35,54 +35,66 @@ impl NbtTag {
 
     pub fn serialize(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
-        bytes.push(self.get_type_id());
-        bytes.extend(self.serialize_data());
+        self.serialize_into(&mut bytes);
         bytes
+    }
+
+    pub fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.push(self.get_type_id());
+        self.serialize_data_into(bytes);
     }
 
     pub fn serialize_data(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
+        self.serialize_data_into(&mut bytes);
+        bytes
+    }
+
+    pub fn serialize_str_into(s: &str, bytes: &mut Vec<u8>) {
+        let java_string = simd_cesu8::encode(s);
+        bytes.extend_from_slice(&(java_string.len() as u16).to_be_bytes());
+        bytes.extend_from_slice(&java_string[..]);
+    }
+
+    pub fn serialize_data_into(&self, bytes: &mut Vec<u8>) {
         match self {
             NbtTag::End => {}
-            NbtTag::Byte(byte) => bytes.extend(byte.to_be_bytes()),
-            NbtTag::Short(short) => bytes.extend(short.to_be_bytes()),
-            NbtTag::Int(int) => bytes.extend(int.to_be_bytes()),
-            NbtTag::Long(long) => bytes.extend(long.to_be_bytes()),
-            NbtTag::Float(float) => bytes.extend(float.to_be_bytes()),
-            NbtTag::Double(double) => bytes.extend(double.to_be_bytes()),
+            NbtTag::Byte(byte) => bytes.extend_from_slice(&byte.to_be_bytes()),
+            NbtTag::Short(short) => bytes.extend_from_slice(&short.to_be_bytes()),
+            NbtTag::Int(int) => bytes.extend_from_slice(&int.to_be_bytes()),
+            NbtTag::Long(long) => bytes.extend_from_slice(&long.to_be_bytes()),
+            NbtTag::Float(float) => bytes.extend_from_slice(&float.to_be_bytes()),
+            NbtTag::Double(double) => bytes.extend_from_slice(&double.to_be_bytes()),
             NbtTag::ByteArray(byte_array) => {
-                bytes.extend((byte_array.len() as i32).to_be_bytes());
-                bytes.extend(byte_array);
+                bytes.extend_from_slice(&(byte_array.len() as i32).to_be_bytes());
+                bytes.extend_from_slice(byte_array);
             }
-            NbtTag::String(string) => {
-                let java_string = simd_cesu8::encode(string);
-                bytes.extend((java_string.len() as u16).to_be_bytes());
-                bytes.extend_from_slice(&java_string[..]);
-            }
+            NbtTag::String(string) => Self::serialize_str_into(string, bytes),
             NbtTag::List(list) => {
-                bytes.extend((list.first().unwrap_or(&NbtTag::End).get_type_id()).to_be_bytes());
-                bytes.extend((list.len() as i32).to_be_bytes());
+                bytes.extend_from_slice(
+                    &(list.first().unwrap_or(&NbtTag::End).get_type_id()).to_be_bytes(),
+                );
+                bytes.extend_from_slice(&(list.len() as i32).to_be_bytes());
                 for nbt_tag in list {
-                    bytes.extend(nbt_tag.serialize_data())
+                    nbt_tag.serialize_data_into(bytes);
                 }
             }
             NbtTag::Compound(compound) => {
-                bytes.extend(compound.serialize_content());
+                compound.serialize_content_into(bytes);
             }
             NbtTag::IntArray(int_array) => {
-                bytes.extend((int_array.len() as i32).to_be_bytes());
+                bytes.extend_from_slice(&(int_array.len() as i32).to_be_bytes());
                 for int in int_array {
-                    bytes.extend(int.to_be_bytes())
+                    bytes.extend_from_slice(&int.to_be_bytes())
                 }
             }
             NbtTag::LongArray(long_array) => {
-                bytes.extend((long_array.len() as i32).to_be_bytes());
+                bytes.extend_from_slice(&(long_array.len() as i32).to_be_bytes());
                 for long in long_array {
-                    bytes.extend(long.to_be_bytes())
+                    bytes.extend_from_slice(&long.to_be_bytes())
                 }
             }
         }
-        bytes
     }
 
     pub fn deserialize(bytes: &[u8]) -> Result<NbtTag, Error> {

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -99,6 +99,31 @@ impl NbtTag {
         }
     }
 
+    pub fn size_hint(&self) -> (usize, usize) {
+        fn same(v: usize) -> (usize, usize) {
+            (v, v)
+        }
+
+        match self {
+            NbtTag::End => same(1),
+            NbtTag::Byte(_) => same(1),
+            NbtTag::Short(_) => same(2),
+            NbtTag::Int(_) => same(4),
+            NbtTag::Long(_) => same(8),
+            NbtTag::Float(_) => same(4),
+            NbtTag::Double(_) => same(8),
+            NbtTag::ByteArray(bytes) => same(4 + bytes.len()),
+            NbtTag::IntArray(items) => same(4 + items.len() * 4),
+            NbtTag::LongArray(items) => same(4 + items.len() * 8),
+            NbtTag::List(nbt_tags) => nbt_tags
+                .iter()
+                .map(NbtTag::size_hint)
+                .fold(same(5), |a, b| (a.0 + b.0, a.1 + b.1)),
+            NbtTag::String(s) => (2 + s.len(), 2 + s.len() * 2),
+            NbtTag::Compound(compound) => compound.size_hint(),
+        }
+    }
+
     pub fn deserialize(bytes: &[u8]) -> Result<NbtTag, Error> {
         Self::deserialize_internal(&mut BinarySliceCursor::new(bytes))
     }

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -51,9 +51,13 @@ impl NbtTag {
     }
 
     pub fn serialize_str_into(s: &str, bytes: &mut Vec<u8>) {
-        let java_string = simd_cesu8::encode(s);
-        bytes.extend_from_slice(&(java_string.len() as u16).to_be_bytes());
-        bytes.extend_from_slice(&java_string[..]);
+        bytes.extend_from_slice(&[0, 0]);
+        let len_before = bytes.len();
+        simd_cesu8::encode_into(s, bytes);
+        let len_after = bytes.len();
+        let len_written = &((len_after - len_before) as u16).to_be_bytes();
+        bytes[len_before - 2] = len_written[0];
+        bytes[len_before - 1] = len_written[1];
     }
 
     pub fn serialize_data_into(&self, bytes: &mut Vec<u8>) {
@@ -79,9 +83,7 @@ impl NbtTag {
                     nbt_tag.serialize_data_into(bytes);
                 }
             }
-            NbtTag::Compound(compound) => {
-                compound.serialize_content_into(bytes);
-            }
+            NbtTag::Compound(compound) => compound.serialize_content_into(bytes),
             NbtTag::IntArray(int_array) => {
                 bytes.extend_from_slice(&(int_array.len() as i32).to_be_bytes());
                 for int in int_array {

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -35,12 +35,20 @@ pub(crate) fn read_array<T, const N: usize, F>(
 where
     F: Fn([u8; N]) -> T,
 {
-    Ok(bytes
-        .read(len * N)?
-        .chunks_exact(N)
-        .map(|chunk| {
-            let arr: [u8; N] = chunk.try_into().expect("chunk size mismatch");
-            from_be(arr)
-        })
-        .collect())
+    let chunks: &[[u8; N]] = bytes.read(len * N)?.as_chunks::<N>().0;
+    if chunks.len() != len {
+        core::hint::cold_path();
+        panic!(
+            "Unexpectedly got {} chunks instead of {} chunks",
+            chunks.len(),
+            len
+        );
+    }
+
+    let mut out = Vec::with_capacity(len);
+    for chunk in chunks {
+        out.push(from_be(*chunk));
+    }
+
+    Ok(out)
 }

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -31,12 +31,11 @@ impl Serializer {
         match &mut self.state {
             State::Named(name) | State::Array { name, .. } => {
                 self.output.push(tag);
-                self.output
-                    .extend(NbtTag::String(name.clone()).serialize_data());
+                NbtTag::serialize_str_into(name, &mut self.output);
             }
             State::FirstListElement { len } => {
                 self.output.push(tag);
-                self.output.extend(len.to_be_bytes().iter());
+                self.output.extend_from_slice(&len.to_be_bytes());
             }
             State::MapKey => {
                 if tag != STRING_ID {
@@ -116,25 +115,25 @@ impl ser::Serializer for &mut Serializer {
 
     fn serialize_i8(self, v: i8) -> Result<()> {
         self.parse_state(BYTE_ID)?;
-        self.output.extend(v.to_be_bytes());
+        self.output.extend_from_slice(&v.to_be_bytes());
         Ok(())
     }
 
     fn serialize_i16(self, v: i16) -> Result<()> {
         self.parse_state(SHORT_ID)?;
-        self.output.extend(v.to_be_bytes());
+        self.output.extend_from_slice(&v.to_be_bytes());
         Ok(())
     }
 
     fn serialize_i32(self, v: i32) -> Result<()> {
         self.parse_state(INT_ID)?;
-        self.output.extend(v.to_be_bytes());
+        self.output.extend_from_slice(&v.to_be_bytes());
         Ok(())
     }
 
     fn serialize_i64(self, v: i64) -> Result<()> {
         self.parse_state(LONG_ID)?;
-        self.output.extend(v.to_be_bytes());
+        self.output.extend_from_slice(&v.to_be_bytes());
         Ok(())
     }
 
@@ -156,13 +155,13 @@ impl ser::Serializer for &mut Serializer {
 
     fn serialize_f32(self, v: f32) -> Result<()> {
         self.parse_state(FLOAT_ID)?;
-        self.output.extend(v.to_be_bytes());
+        self.output.extend_from_slice(&v.to_be_bytes());
         Ok(())
     }
 
     fn serialize_f64(self, v: f64) -> Result<()> {
         self.parse_state(DOUBLE_ID)?;
-        self.output.extend(v.to_be_bytes());
+        self.output.extend_from_slice(&v.to_be_bytes());
         Ok(())
     }
 
@@ -177,8 +176,7 @@ impl ser::Serializer for &mut Serializer {
             return Ok(());
         }
 
-        self.output
-            .extend(NbtTag::String(v.to_string()).serialize_data());
+        NbtTag::String(v.to_string()).serialize_data_into(&mut self.output);
         Ok(())
     }
 
@@ -273,7 +271,8 @@ impl ser::Serializer for &mut Serializer {
                     }
                 };
                 self.parse_state(id)?;
-                self.output.extend((len.unwrap() as i32).to_be_bytes());
+                self.output
+                    .extend_from_slice(&(len.unwrap() as i32).to_be_bytes());
                 self.state = State::ListElement;
             }
             _ => {
@@ -282,7 +281,7 @@ impl ser::Serializer for &mut Serializer {
                 // If the list is empty, FirstListElement is never parsed
                 if len.unwrap() == 0 {
                     self.output.push(END_ID);
-                    self.output.extend(0_i32.to_be_bytes());
+                    self.output.extend_from_slice(&0_i32.to_be_bytes());
                 }
 
                 self.state = State::FirstListElement {
@@ -331,16 +330,14 @@ impl ser::Serializer for &mut Serializer {
         match &mut self.state {
             State::Root(root_name) => {
                 if let Some(root_name) = root_name {
-                    self.output
-                        .extend(NbtTag::String(root_name.clone()).serialize_data());
+                    NbtTag::serialize_str_into(root_name, &mut self.output);
                 }
             }
             State::Named(string) => {
-                self.output
-                    .extend(NbtTag::String(string.clone()).serialize_data());
+                NbtTag::serialize_str_into(string, &mut self.output);
             }
             State::FirstListElement { len } => {
-                self.output.extend(len.to_be_bytes());
+                self.output.extend_from_slice(&len.to_be_bytes());
             }
             _ => {
                 unimplemented!()

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -176,7 +176,7 @@ impl ser::Serializer for &mut Serializer {
             return Ok(());
         }
 
-        NbtTag::String(v.to_string()).serialize_data_into(&mut self.output);
+        NbtTag::serialize_str_into(v, &mut self.output);
         Ok(())
     }
 


### PR DESCRIPTION
vs refactor/remove-bytes:

Gungraun
```
gungraun::read_group::read complex_player:(read_file("tests/data/complex_player.dat"))
  ======= CALLGRIND ====================================================================
  Instructions:                      156945|158441               (-0.94420%) [-1.00953x]
  L1 Hits:                           215760|218863               (-1.41778%) [-1.01438x]
  LL Hits:                              426|427                  (-0.23419%) [-1.00235x]
  RAM Hits:                              85|85                   (No change)
  Total read+write:                  216271|219375               (-1.41493%) [-1.01435x]
  Estimated Cycles:                  220865|223973               (-1.38767%) [-1.01407x]
  ======= DHAT =========================================================================
  Total bytes:                        23658|23658                (No change)
  Total blocks:                         317|317                  (No change)
  At t-gmax bytes:                        0|0                    (No change)
  At t-gmax blocks:                       0|0                    (No change)
  At t-end bytes:                         0|0                    (No change)
  At t-end blocks:                        0|0                    (No change)
  Reads bytes:                        20845|20845                (No change)
  Writes bytes:                       19906|19906                (No change)
gungraun::read_group::read chunk:(read_file("tests/data/chunk.nbt"))
  ======= CALLGRIND ====================================================================
  Instructions:                      374038|366697               (+2.00193%) [+1.02002x]
  L1 Hits:                           512745|495402               (+3.50079%) [+1.03501x]
  LL Hits:                             2020|2025                 (-0.24691%) [-1.00248x]
  RAM Hits:                             463|466                  (-0.64378%) [-1.00648x]
  Total read+write:                  515228|497893               (+3.48167%) [+1.03482x]
  Estimated Cycles:                  539050|521837               (+3.29854%) [+1.03299x]
  ======= DHAT =========================================================================
  Total bytes:                        62716|62716                (No change)
  Total blocks:                         334|334                  (No change)
  At t-gmax bytes:                    62044|62044                (No change)
  At t-gmax blocks:                     332|332                  (No change)
  At t-end bytes:                         0|0                    (No change)
  At t-end blocks:                        0|0                    (No change)
  Reads bytes:                        12653|12653                (No change)
  Writes bytes:                       53924|53924                (No change)
gungraun::write_group::write complex_player:(read_file_to_nbt("tests/data/complex_player.dat")...
  ======= CALLGRIND ====================================================================
  Instructions:                      118093|355072               (-66.7411%) [-3.00672x]
  L1 Hits:                           171433|501785               (-65.8354%) [-2.92700x]
  LL Hits:                              355|1034                 (-65.6673%) [-2.91268x]
  RAM Hits:                              52|128                  (-59.3750%) [-2.46154x]
  Total read+write:                  171840|502947               (-65.8334%) [-2.92683x]
  Estimated Cycles:                  175028|511435               (-65.7771%) [-2.92202x]
  ======= DHAT =========================================================================
  Total bytes:                         3380|40613                (-91.6775%) [-12.0157x]
  Total blocks:                           1|946                  (-99.8943%) [-946.000x]
  At t-gmax bytes:                        0|0                    (No change)
  At t-gmax blocks:                       0|0                    (No change)
  At t-end bytes:                         0|0                    (No change)
  At t-end blocks:                        0|0                    (No change)
  Reads bytes:                            0|31864                (-100.000%) [---inf---]
  Writes bytes:                        3936|33722                (-88.3281%) [-8.56758x]
gungraun::write_group::write chunk:(read_file_to_nbt("tests/data/chunk.nbt"))
  ======= CALLGRIND ====================================================================
  Instructions:                      315736|1111765              (-71.6005%) [-3.52119x]
  L1 Hits:                           452053|1693890              (-73.3127%) [-3.74710x]
  LL Hits:                             3748|5901                 (-36.4853%) [-1.57444x]
  RAM Hits:                              56|1472                 (-96.1957%) [-26.2857x]
  Total read+write:                  455857|1701263              (-73.2048%) [-3.73201x]
  Estimated Cycles:                  472753|1774915              (-73.3648%) [-3.75442x]
  ======= DHAT =========================================================================
  Total bytes:                        44331|645941               (-93.1370%) [-14.5709x]
  Total blocks:                           1|1160                 (-99.9138%) [-1160.00x]
  At t-gmax bytes:                    44331|132563               (-66.5585%) [-2.99030x]
  At t-gmax blocks:                       1|2                    (-50.0000%) [-2.00000x]
  At t-end bytes:                         0|0                    (No change)
  At t-end blocks:                        0|0                    (No change)
  Reads bytes:                            0|485284               (-100.000%) [---inf---]
  Writes bytes:                       45499|528255               (-91.3869%) [-11.6103x]
  ```
  
  Criterion
  ```
read/complex_player     time:   [10.538 µs 10.676 µs 10.793 µs]
                        thrpt:  [298.65 MiB/s 301.93 MiB/s 305.87 MiB/s]
                 change:
                        time:   [-3.3676% -0.5746% +2.4782%] (p = 0.71 > 0.05)
                        thrpt:  [-2.4183% +0.5779% +3.4850%]
                        No change in performance detected.

read/chunk              time:   [33.164 µs 33.667 µs 34.099 µs]
                        thrpt:  [1.2108 GiB/s 1.2263 GiB/s 1.2449 GiB/s]
                 change:
                        time:   [-7.9041% -4.1813% -0.4430%] (p = 0.03 < 0.05)
                        thrpt:  [+0.4450% +4.3638% +8.5824%]
                        Change within noise threshold.

     Running benches/write.rs (target/release/deps/write-15fb80df67147bb8)
write/complex_player    time:   [2.5407 µs 2.5644 µs 2.5854 µs]
                        thrpt:  [1.2175 GiB/s 1.2275 GiB/s 1.2390 GiB/s]
                 change:
                        time:   [-83.944% -83.708% -83.469%] (p = 0.00 < 0.05)
                        thrpt:  [+504.92% +513.79% +522.83%]
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  18 (18.00%) low mild

write/chunk             time:   [10.866 µs 10.945 µs 11.025 µs]
                        thrpt:  [3.7447 GiB/s 3.7721 GiB/s 3.7997 GiB/s]
                 change:
                        time:   [-80.070% -79.321% -78.612%] (p = 0.00 < 0.05)
                        thrpt:  [+367.55% +383.58% +401.77%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) low mild
  ```