### PR TITLE
fix! Remove ability to create heterogeneous lists

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,10 @@ nightly = ["simd_cesu8/nightly"]
 [dependencies]
 bytes = "1.10.0"
 simd_cesu8 = "1.0.1"
-derive_more = { version = "2.0.1", features = ["into", "from"] }
+derive_more = { version = "2.0.1", features = ["into", "from", "try_into"] }
 thiserror = "2.0.11"
 serde = { version = "1.0.218", optional = true, features = ["derive"] }
+as-any = "0.3.2"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,13 @@
 pub mod error;
 mod macros;
 mod nbt;
+mod utils;
 #[cfg(feature = "serde")]
 pub mod serde;
 
 pub use crab_nbt::nbt::compound::NbtCompound;
 pub use crab_nbt::nbt::tag::NbtTag;
 pub use crab_nbt::nbt::Nbt;
+pub use crab_nbt::utils::{TryAsRef, TryAsMut};
 
 extern crate self as crab_nbt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,14 +5,12 @@ mod macros;
 mod nbt;
 #[cfg(feature = "serde")]
 pub mod serde;
-mod utils;
 
 pub use crab_nbt::nbt::compound::NbtCompound;
 pub use crab_nbt::nbt::list::NbtList;
 pub use crab_nbt::nbt::nbt_trait::NbtCompatible;
 pub use crab_nbt::nbt::tag::NbtTag;
 pub use crab_nbt::nbt::Nbt;
-pub use crab_nbt::utils::{TryAsMut, TryAsRef};
 // Trick to allow &str in nbt! macro. Must be public.
 pub use crab_nbt::macros::IntoNbtCompatible;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,14 @@
 pub mod error;
 mod macros;
 mod nbt;
-mod utils;
 #[cfg(feature = "serde")]
 pub mod serde;
+mod utils;
 
 pub use crab_nbt::nbt::compound::NbtCompound;
+pub use crab_nbt::nbt::list::NbtList;
 pub use crab_nbt::nbt::tag::NbtTag;
 pub use crab_nbt::nbt::Nbt;
-pub use crab_nbt::utils::{TryAsRef, TryAsMut};
+pub use crab_nbt::utils::{TryAsMut, TryAsRef};
 
 extern crate self as crab_nbt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,11 @@ mod utils;
 
 pub use crab_nbt::nbt::compound::NbtCompound;
 pub use crab_nbt::nbt::list::NbtList;
+pub use crab_nbt::nbt::nbt_trait::NbtCompatible;
 pub use crab_nbt::nbt::tag::NbtTag;
 pub use crab_nbt::nbt::Nbt;
 pub use crab_nbt::utils::{TryAsMut, TryAsRef};
+// Trick to allow &str in nbt! macro. Must be public.
+pub use crab_nbt::macros::IntoNbtCompatible;
 
 extern crate self as crab_nbt;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,26 @@
+use crate::nbt::nbt_trait::PrivateNbtCompatible;
+
+/// Trick trait to help the [`crate::nbt!`] macro to handle [`str`] literals.
+trait IntoNbtCompatible {
+    type Output;
+
+    fn into_compatible(self) -> Self::Output;
+}
+impl<T: PrivateNbtCompatible> IntoNbtCompatible for T {
+    type Output = T;
+
+    fn into_compatible(self) -> Self::Output {
+        self
+    }
+}
+impl<'a> IntoNbtCompatible for &'a str {
+    type Output = String;
+
+    fn into_compatible(self) -> Self::Output {
+        self.to_string()
+    }
+}
+
 /// Macro that simplifies the creation of NBT using JSON/SNBT-like syntax.
 /// It takes a name and a content block, and returns an `Nbt` object.
 ///
@@ -84,10 +107,11 @@ macro_rules! nbt_inner {
         $crate::NbtTag::ByteArray(::bytes::Bytes::from_iter([$($lit),*]))
     };
     ([$($lit:literal),* $(,)?]) => {
-        $crate::NbtTag::List(::std::vec![$($lit.into()),*])
+        // FIXME: The new structure of NbtList needs to be incorporated into the nbt macro
+        $crate::NbtTag::List((::std::vec![$($lit),*]).into())
     };
     ([$($t:tt),* $(,)?]) => {
-        $crate::NbtTag::List(::std::vec![$(nbt_inner!($t).into()),*])
+        $crate::NbtTag::List((::std::vec![$(nbt_inner!($t)),*]).into())
     };
 
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,22 +1,22 @@
-use crate::nbt::nbt_trait::PrivateNbtCompatible;
-
-/// Trick trait to help the [`crate::nbt!`] macro to handle [`str`] literals.
-trait IntoNbtCompatible {
+/// This is a secret trait to help the [`crate::nbt!`] macro handle [`str`] literals.
+/// It is unfortunately not possible to fully hide this trait as the macro needs to be able to use it at every call site.
+#[doc(hidden)]
+pub trait IntoNbtCompatible {
     type Output;
 
-    fn into_compatible(self) -> Self::Output;
+    fn into_nbt_compatible(self) -> Self::Output;
 }
-impl<T: PrivateNbtCompatible> IntoNbtCompatible for T {
+impl<T: ::crab_nbt::NbtCompatible> IntoNbtCompatible for T {
     type Output = T;
 
-    fn into_compatible(self) -> Self::Output {
+    fn into_nbt_compatible(self) -> Self::Output {
         self
     }
 }
 impl<'a> IntoNbtCompatible for &'a str {
     type Output = String;
 
-    fn into_compatible(self) -> Self::Output {
+    fn into_nbt_compatible(self) -> Self::Output {
         self.to_string()
     }
 }
@@ -107,8 +107,10 @@ macro_rules! nbt_inner {
         $crate::NbtTag::ByteArray(::bytes::Bytes::from_iter([$($lit),*]))
     };
     ([$($lit:literal),* $(,)?]) => {
-        // FIXME: The new structure of NbtList needs to be incorporated into the nbt macro
-        $crate::NbtTag::List((::std::vec![$($lit),*]).into())
+        {
+            use $crate::IntoNbtCompatible as _;
+            $crate::NbtTag::List((::std::vec![$($lit.into_nbt_compatible()),*]).into())
+        }
     };
     ([$($t:tt),* $(,)?]) => {
         $crate::NbtTag::List((::std::vec![$(nbt_inner!($t)),*]).into())

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -13,7 +13,7 @@ impl<T: ::crab_nbt::NbtCompatible> IntoNbtCompatible for T {
         self
     }
 }
-impl<'a> IntoNbtCompatible for &'a str {
+impl IntoNbtCompatible for &str {
     type Output = String;
 
     fn into_nbt_compatible(self) -> Self::Output {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -106,7 +106,10 @@ macro_rules! nbt_inner {
     ([Byte; $($lit:literal),* $(,)?]) => {
         $crate::NbtTag::ByteArray(::bytes::Bytes::from_iter([$($lit),*]))
     };
-    ([$($lit:literal),* $(,)?]) => {
+    ([]) => {
+        $crate::NbtTag::List($crate::NbtList::End)
+    };
+    ([$($lit:literal),+ $(,)?]) => {
         {
             use $crate::IntoNbtCompatible as _;
             $crate::NbtTag::List((::std::vec![$($lit.into_nbt_compatible()),*]).into())

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -8,7 +8,9 @@ use std::io::{Cursor, Write};
 use std::ops::Deref;
 
 pub mod compound;
+pub mod list;
 pub mod tag;
+pub mod nbt_trait;
 pub mod utils;
 
 /// Represents the main NBT structure.

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -9,8 +9,8 @@ use std::ops::Deref;
 
 pub mod compound;
 pub mod list;
+pub(crate) mod nbt_trait;
 pub mod tag;
-pub mod nbt_trait;
 pub mod utils;
 
 /// Represents the main NBT structure.

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -1,3 +1,4 @@
+use crate::nbt::list::NbtList;
 use crate::nbt::utils::{escape_name, join_formatted};
 use crate::{error::Error, Nbt};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
@@ -111,7 +112,7 @@ impl NbtCompound {
         self.get(name).and_then(|tag| tag.extract_string())
     }
 
-    pub fn get_list(&self, name: &str) -> Option<&Vec<NbtTag>> {
+    pub fn get_list(&self, name: &str) -> Option<&NbtList> {
         self.get(name).and_then(|tag| tag.extract_list())
     }
 

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -1,11 +1,12 @@
 use crate::nbt::list::NbtList;
-use crate::nbt::utils::{escape_name, join_formatted};
+use crate::nbt::nbt_trait::PrivateNbtCompatible;
+use crate::nbt::utils::{escape_name, ids, join_formatted};
 use crate::{error::Error, Nbt};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crab_nbt::nbt::tag::NbtTag;
 use crab_nbt::nbt::utils::{get_nbt_string, END_ID};
 use derive_more::Into;
-use std::fmt::{self, Debug, Display, Formatter};
+use std::fmt::{self, Debug, Display, Formatter, Result as FmtResult};
 use std::io::{Cursor, Write};
 use std::vec::IntoIter;
 
@@ -177,5 +178,31 @@ impl Display for NbtCompound {
         join_formatted(f, ", ", iterator)?;
 
         write!(f, "}}")
+    }
+}
+impl PrivateNbtCompatible for NbtCompound {
+    fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{self}")
+    }
+
+    fn deserialize_data(bytes: &mut impl Buf) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        Ok(NbtCompound::deserialize_content(bytes)?)
+    }
+
+    fn serialize_data(&self, bytes: &mut impl BufMut)
+    where
+        Self: Sized,
+    {
+        bytes.put(self.serialize_content());
+    }
+
+    fn get_id() -> u8
+    where
+        Self: Sized,
+    {
+        ids::COMPOUND_ID
     }
 }

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -189,7 +189,7 @@ impl PrivateNbtCompatible for NbtCompound {
     where
         Self: Sized,
     {
-        Ok(NbtCompound::deserialize_content(bytes)?)
+        NbtCompound::deserialize_content(bytes)
     }
 
     fn serialize_data(&self, bytes: &mut impl BufMut)

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -55,7 +55,7 @@ impl NbtCompound {
         bytes.freeze()
     }
 
-    pub fn serialize_content_into(&self, bytes: &mut BytesMut) {
+    pub fn serialize_content_into(&self, bytes: &mut impl BufMut) {
         for (name, tag) in &self.child_tags {
             bytes.put_u8(tag.get_type_id());
             serialize_str_into(name, bytes);
@@ -200,7 +200,7 @@ impl PrivateNbtCompatible for NbtCompound {
     where
         Self: Sized,
     {
-        bytes.put(self.serialize_content());
+        self.serialize_content_into(bytes);
     }
 
     fn get_id() -> u8

--- a/src/nbt/list.rs
+++ b/src/nbt/list.rs
@@ -6,11 +6,11 @@ use derive_more::{From, TryInto};
 use crate::{NbtCompound, nbt::{nbt_trait::NbtCompatible, utils::{ids::*, write_listlike}}};
 
 macro_rules! call_uniform {
-    ($self:ident.$($expression:tt)+) => {
+    (($self:ident.$($expression:tt)+), $end_case:expr) => {
         {
             use self::NbtList::*;
             match $self {
-                End => todo!("End case in call_uniform"),
+                End => $end_case,
                 Byte(x) => x.$($expression)*,
                 Short(x) => x.$($expression)*,
                 Int(x) => x.$($expression)*,
@@ -69,11 +69,11 @@ impl NbtList {
     }
 
     pub fn get(&self, index: usize) -> Option<&dyn NbtCompatible> {
-        call_uniform!(self.get(index).map(|x| x as &dyn NbtCompatible))
+        call_uniform!((self.get(index).map(|x| x as &dyn NbtCompatible)), None)
     }
 
     pub fn get_mut<'a>(&'a mut self, index: usize) -> Option<&'a mut dyn NbtCompatible > {
-        call_uniform!(self.get_mut(index).map(|x| x as &mut dyn NbtCompatible))
+        call_uniform!((self.get_mut(index).map(|x| x as &mut dyn NbtCompatible)), None)
     }
 
     pub fn iter(&self) -> Iter<'_> {
@@ -89,12 +89,12 @@ impl Index<usize> for NbtList {
     type Output = dyn NbtCompatible;
 
     fn index(&self, index: usize) -> &Self::Output {
-        call_uniform!(self.index(index))
+        call_uniform!((self.index(index)), panic!("Index out of bounds for empty list. Index {index}"))
     }
 }
 impl IndexMut<usize> for NbtList {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        call_uniform!(self.index_mut(index))
+        call_uniform!((self.index_mut(index)), panic!("Index out of bounds for empty list. Index {index}"))
     }
 }
 impl<'a> IntoIterator for &'a NbtList {
@@ -117,19 +117,30 @@ impl<'a> IntoIterator for &'a mut NbtList {
 }
 impl Display for NbtList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write_listlike(f, "", "", self.iter())
+        // call_uniform!((self, |x: _| write_listlike(f, "", "", x.iter())), Ok(()))
+        write_listlike(f, "", "", self.iter().map(|e| e.snbt_dyn()))
     }
 }
 
 macro_rules! impl_TryAsRefAndMut {
+    // empty lists are always serialized as lists of type TAG_END in NBT
+    // such a list could have any type, so all TryAsRef and TryAsMut calls must succeed on it.
+    // to ensure that no behaviour changes occur between reloading of a list, any TryAsRef and TryAsMut on empty lists succeeds.
     ($(($variant:ident, $type:ty)),+) => {
         use crate::{TryAsRef, TryAsMut};
         $(
             impl TryAsRef<Vec<$type>> for NbtList {
                 fn try_as_ref(&self) -> Option<&Vec<$type>> {
+                    static EMPTY_VEC: Vec<$type> = Vec::new();
                     match self {
                         Self::$variant(x) => Some(x),
-                        _ => None
+                        _ => {
+                            if self.is_empty() {
+                                Some(&EMPTY_VEC)
+                            } else {
+                                None
+                            }
+                        }
                     }
                 }
             }
@@ -137,7 +148,17 @@ macro_rules! impl_TryAsRefAndMut {
                 fn try_as_mut(&mut self) -> Option<&mut Vec<$type>> {
                     match self {
                         Self::$variant(x) => Some(x),
-                        _ => None
+                        _ => {
+                            if self.is_empty() {
+                                *self = Self::$variant(Vec::new());
+                                match self {
+                                    Self::$variant(x) => Some(x),
+                                    _ => unreachable!()
+                                }
+                            } else {
+                                None
+                            }
+                        }
                     }
                 }
             }
@@ -145,13 +166,13 @@ macro_rules! impl_TryAsRefAndMut {
     };
 }
 macro_rules! implUniformMethods {
-    ($($method:ident($($modifiers:tt),*;$($param_name:ident: $param_type:ty),*) $(-> $return:ty)?),+) => {
+    ($($method:ident($($modifiers:tt),*;$($param_name:ident: $param_type:ty),*) $(-> $return:ty)? | $on_end:expr),+) => {
         impl NbtList {
             $(
                 pub fn $method($($modifiers)*self, $($param_name: $param_type),*) $(-> $return)? {
                     use self::NbtList::*;
                     match self {
-                        End => todo!("End tag in implUniformMethods"),
+                        End => $on_end,
                         Byte(x) => x.$method($($param_name),*),
                         Short(x) => x.$method($($param_name),*),
                         Int(x) => x.$method($($param_name),*),
@@ -172,22 +193,18 @@ macro_rules! implUniformMethods {
 }
 // TODO: Is it better to implement or not to implement these methods?
 implUniformMethods! {
-    len(&;) -> usize,
-    capacity(&;) -> usize,
-    reserve(&,mut; additional: usize),
-    reserve_exact(&,mut; additional: usize),
-    try_reserve(&,mut; additional: usize) -> Result<(), std::collections::TryReserveError>,
-    try_reserve_exact(&,mut; additional: usize) -> Result<(), std::collections::TryReserveError>,
-    shrink_to_fit(&,mut;),
-    shrink_to(&,mut; min_capacity: usize),
-    truncate(&,mut; len: usize),
-    clear(&,mut;),
-    is_empty(&,mut;) -> bool,
-    dedup(&,mut;),
-    swap(&,mut; a: usize, b: usize),
-    reverse(&,mut;),
-    rotate_left(&,mut; mid: usize),
-    rotate_right(&,mut; k: usize)
+    len(&;) -> usize | 0,
+    capacity(&;) -> usize | 0,
+    shrink_to_fit(&,mut;) | (),
+    shrink_to(&,mut; min_capacity: usize) | (),
+    truncate(&,mut; len: usize) | (),
+    clear(&,mut;) | (),
+    is_empty(&;) -> bool | true,
+    dedup(&,mut;) | (),
+    swap(&,mut; a: usize, b: usize) | panic!("Tried to swap on an empty list with. {a}<->{b}"),
+    reverse(&,mut;) | (),
+    rotate_left(&,mut; mid: usize) | if mid > 0 { panic!("Tried to rotate an empty list") },
+    rotate_right(&,mut; k: usize) | if k > 0 { panic!("Tried to rotate an empty list") }
     
 }
 

--- a/src/nbt/list.rs
+++ b/src/nbt/list.rs
@@ -1,0 +1,263 @@
+use std::{fmt::Display, ops::{Index, IndexMut}};
+
+use bytes::Bytes;
+use derive_more::{From, TryInto};
+
+use crate::{NbtCompound, nbt::{nbt_trait::NbtCompatible, utils::{ids::*, write_listlike}}};
+
+macro_rules! call_uniform {
+    ($self:ident.$($expression:tt)+) => {
+        {
+            use self::NbtList::*;
+            match $self {
+                End => todo!("End case in call_uniform"),
+                Byte(x) => x.$($expression)*,
+                Short(x) => x.$($expression)*,
+                Int(x) => x.$($expression)*,
+                Long(x) => x.$($expression)*,
+                Float(x) => x.$($expression)*,
+                Double(x) => x.$($expression)*,
+                ByteArray(x) => x.$($expression)*,
+                String(x) => x.$($expression)*,
+                List(x) => x.$($expression)*,
+                Compound(x) => x.$($expression)*,
+                IntArray(x) => x.$($expression)*,
+                LongArray(x) => x.$($expression)*,
+            }
+        }
+    };
+}
+
+#[derive(Clone, Debug, PartialEq, PartialOrd, From, TryInto)]
+#[repr(u8)]
+pub enum NbtList {
+    // TODO: Everything about End.
+    //  This is needed because an empty list serializes to a list of type END_TAG
+    //  Need to check how this can be treated in various applications
+    End = END_ID,
+    Byte(Vec<i8>) = BYTE_ID,
+    Short(Vec<i16>) = SHORT_ID,
+    Int(Vec<i32>) = INT_ID,
+    Long(Vec<i64>) = LONG_ID,
+    Float(Vec<f32>) = FLOAT_ID,
+    Double(Vec<f64>) = DOUBLE_ID,
+    ByteArray(Vec<Bytes>) = BYTE_ARRAY_ID,
+    String(Vec<String>) = STRING_ID,
+    List(Vec<NbtList>) = LIST_ID,
+    Compound(Vec<NbtCompound>) = COMPOUND_ID,
+    IntArray(Vec<Vec<i32>>) = INT_ARRAY_ID,
+    LongArray(Vec<Vec<i64>>) = LONG_ARRAY_ID,
+}
+impl NbtList {
+    pub fn get_type_id(&self) -> u8 {
+        use self::NbtList::*;
+        match self {
+            End => END_ID,
+            Byte(_) => BYTE_ID,
+            Short(_) => SHORT_ID,
+            Int(_) => INT_ID,
+            Long(_) => LONG_ID,
+            Float(_) => FLOAT_ID,
+            Double(_) => DOUBLE_ID,
+            ByteArray(_)  => BYTE_ARRAY_ID,
+            String(_) => STRING_ID,
+            List(_) => LIST_ID,
+            Compound(_) => COMPOUND_ID,
+            IntArray(_) => INT_ARRAY_ID,
+            LongArray(_) => LONG_ARRAY_ID
+        }
+    }
+
+    pub fn get(&self, index: usize) -> Option<&dyn NbtCompatible> {
+        call_uniform!(self.get(index).map(|x| x as &dyn NbtCompatible))
+    }
+
+    pub fn get_mut<'a>(&'a mut self, index: usize) -> Option<&'a mut dyn NbtCompatible > {
+        call_uniform!(self.get_mut(index).map(|x| x as &mut dyn NbtCompatible))
+    }
+
+    pub fn iter(&self) -> Iter<'_> {
+        self.into_iter()
+    }
+
+    pub fn iter_mut(&mut self) -> IterMut<'_> {
+        self.into_iter()
+    }
+}
+// Slice indexes are impossible on erased vecs, because there is no uniform output type
+impl Index<usize> for NbtList {
+    type Output = dyn NbtCompatible;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        call_uniform!(self.index(index))
+    }
+}
+impl IndexMut<usize> for NbtList {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        call_uniform!(self.index_mut(index))
+    }
+}
+impl<'a> IntoIterator for &'a NbtList {
+    type Item = &'a dyn NbtCompatible;
+
+    type IntoIter = Iter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Self::IntoIter::new(self)
+    }
+}
+impl<'a> IntoIterator for &'a mut NbtList {
+    type Item = &'a mut dyn NbtCompatible;
+
+    type IntoIter = IterMut<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Self::IntoIter::new(self)
+    }
+}
+impl Display for NbtList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write_listlike(f, "", "", self.iter())
+    }
+}
+
+macro_rules! impl_TryAsRefAndMut {
+    ($(($variant:ident, $type:ty)),+) => {
+        use crate::{TryAsRef, TryAsMut};
+        $(
+            impl TryAsRef<Vec<$type>> for NbtList {
+                fn try_as_ref(&self) -> Option<&Vec<$type>> {
+                    match self {
+                        Self::$variant(x) => Some(x),
+                        _ => None
+                    }
+                }
+            }
+            impl TryAsMut<Vec<$type>> for NbtList {
+                fn try_as_mut(&mut self) -> Option<&mut Vec<$type>> {
+                    match self {
+                        Self::$variant(x) => Some(x),
+                        _ => None
+                    }
+                }
+            }
+        )+
+    };
+}
+macro_rules! implUniformMethods {
+    ($($method:ident($($modifiers:tt),*;$($param_name:ident: $param_type:ty),*) $(-> $return:ty)?),+) => {
+        impl NbtList {
+            $(
+                pub fn $method($($modifiers)*self, $($param_name: $param_type),*) $(-> $return)? {
+                    use self::NbtList::*;
+                    match self {
+                        End => todo!("End tag in implUniformMethods"),
+                        Byte(x) => x.$method($($param_name),*),
+                        Short(x) => x.$method($($param_name),*),
+                        Int(x) => x.$method($($param_name),*),
+                        Long(x) => x.$method($($param_name),*),
+                        Float(x) => x.$method($($param_name),*),
+                        Double(x) => x.$method($($param_name),*),
+                        ByteArray(x) => x.$method($($param_name),*),
+                        String(x) => x.$method($($param_name),*),
+                        List(x) => x.$method($($param_name),*),
+                        Compound(x) => x.$method($($param_name),*),
+                        IntArray(x) => x.$method($($param_name),*),
+                        LongArray(x) => x.$method($($param_name),*),
+                    }
+                }
+            )+
+        }
+    };
+}
+// TODO: Is it better to implement or not to implement these methods?
+implUniformMethods! {
+    len(&;) -> usize,
+    capacity(&;) -> usize,
+    reserve(&,mut; additional: usize),
+    reserve_exact(&,mut; additional: usize),
+    try_reserve(&,mut; additional: usize) -> Result<(), std::collections::TryReserveError>,
+    try_reserve_exact(&,mut; additional: usize) -> Result<(), std::collections::TryReserveError>,
+    shrink_to_fit(&,mut;),
+    shrink_to(&,mut; min_capacity: usize),
+    truncate(&,mut; len: usize),
+    clear(&,mut;),
+    is_empty(&,mut;) -> bool,
+    dedup(&,mut;),
+    swap(&,mut; a: usize, b: usize),
+    reverse(&,mut;),
+    rotate_left(&,mut; mid: usize),
+    rotate_right(&,mut; k: usize)
+    
+}
+
+impl_TryAsRefAndMut! {
+    (Byte, i8),
+    (Short, i16),
+    (Int, i32),
+    (Long, i64),
+    (Float, f32),
+    (Double, f64),
+    (ByteArray, Bytes),
+    (String, String),
+    (List, NbtList),
+    (Compound, NbtCompound),
+    (IntArray, Vec<i32>),
+    (LongArray, Vec<i64>)
+}
+
+pub struct Iter<'a> {
+    list: &'a NbtList,
+    index: Option<usize>
+}
+impl<'a> Iter<'a> {
+    fn new(list: &'a NbtList) -> Self {
+        Self { list, index: Some(0) }
+    }
+}
+impl<'a> Iterator for Iter<'a> {
+    type Item = &'a dyn NbtCompatible;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = self.index?;
+        let val = self.list.get(index);
+        if val.is_some() {
+            self.index = Some(index.strict_add(1));
+        } else {
+            self.index = None;
+        }
+        val
+    }
+}
+
+pub struct IterMut<'a> {
+    list: &'a mut NbtList,
+    index: Option<usize>
+}
+impl<'a> IterMut<'a> {
+    fn new(list: &'a mut NbtList) -> Self {
+        Self { list, index: Some(0) }
+    }
+}
+impl<'a> Iterator for IterMut<'a> {
+    type Item = &'a mut dyn NbtCompatible;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = self.index?;
+        let val: Option<&'a mut dyn NbtCompatible> = self.list.get_mut(index)
+            // The borrow checker is being too eager with get_mut and degrades lifetime 'a to the lifetime of self.
+            // For reasons unknown to me this only happens with mutable pointers.
+            // Other methods of lifetime expansion (such as pointer casting) have proven unsuccessful, so transmute is used as a last resort.
+            // SAFETY:
+            //  Expanding the lifetime is safe in this instance, because the borrow checker already guarantees
+            //  that self.list will live for 'a, because we are holding a borrow of it for that lifetime.
+            //  get_mut ensures that its return value has lifetime 'a as well, so our reference must live for at least that long.
+            .map(|r| unsafe { std::mem::transmute(r) });
+        if val.is_some() {
+            self.index = Some(index.strict_add(1));
+        } else {
+            self.index = None;
+        }
+        val
+    }
+}

--- a/src/nbt/list.rs
+++ b/src/nbt/list.rs
@@ -53,43 +53,28 @@ use crate::{
 macro_rules! nbt_list_call_uniform {
     ($self:expr,$content:ident, $expression:expr, $end_case:expr) => {
         {
-            use $crate::NbtList::*;
             match $self {
-                End => $end_case,
-                Byte($content) => $expression,
-                Short($content) => $expression,
-                Int($content) => $expression,
-                Long($content) => $expression,
-                Float($content) => $expression,
-                Double($content) => $expression,
-                ByteArray($content) => $expression,
-                String($content) => $expression,
-                List($content) => $expression,
-                Compound($content) => $expression,
-                IntArray($content) => $expression,
-                LongArray($content) => $expression,
+                // Manual reference for each value to avoid namespace pollution when using the macro
+                // If we used a "use" statement for this, $expression and $end_case would inherit that context,
+                // potentially causing undesirable type collisions
+                $crate::NbtList::End => $end_case,
+                $crate::NbtList::Byte($content) => $expression,
+                $crate::NbtList::Short($content) => $expression,
+                $crate::NbtList::Int($content) => $expression,
+                $crate::NbtList::Long($content) => $expression,
+                $crate::NbtList::Float($content) => $expression,
+                $crate::NbtList::Double($content) => $expression,
+                $crate::NbtList::ByteArray($content) => $expression,
+                $crate::NbtList::String($content) => $expression,
+                $crate::NbtList::List($content) => $expression,
+                $crate::NbtList::Compound($content) => $expression,
+                $crate::NbtList::IntArray($content) => $expression,
+                $crate::NbtList::LongArray($content) => $expression,
             }
         }
     };
-    (($self:ident.$($expression:tt)+), $end_case:expr) => {
-        {
-            use $crate::NbtList::*;
-            match $self {
-                End => $end_case,
-                Byte(x) => x.$($expression)*,
-                Short(x) => x.$($expression)*,
-                Int(x) => x.$($expression)*,
-                Long(x) => x.$($expression)*,
-                Float(x) => x.$($expression)*,
-                Double(x) => x.$($expression)*,
-                ByteArray(x) => x.$($expression)*,
-                String(x) => x.$($expression)*,
-                List(x) => x.$($expression)*,
-                Compound(x) => x.$($expression)*,
-                IntArray(x) => x.$($expression)*,
-                LongArray(x) => x.$($expression)*,
-            }
-        }
+    (($self:ident.$($method:tt)+), $end_case:expr) => {
+        nbt_list_call_uniform!($self,x, x.$($method)*, $end_case)
     };
 }
 

--- a/src/nbt/list.rs
+++ b/src/nbt/list.rs
@@ -281,6 +281,11 @@ macro_rules! impl_TryAsRefAndMut {
         )+
     };
 }
+/// Implements [`Vec`] methods on the NbtList by delegating the method call.
+/// Can only be used on methods whose signature is independent of the list type.
+///
+/// The `on_end` expression (the expression after the `|`) **must** be identical
+/// to the return value on every other variant of [`NbtList`] when the contained [`Vec`] is empty.
 macro_rules! implUniformMethods {
     ($($method:ident($($modifiers:tt),*;$($param_name:ident: $param_type:ty),*) $(-> $return:ty)? | $on_end:expr),+) => {
         impl NbtList {
@@ -307,7 +312,7 @@ macro_rules! implUniformMethods {
         }
     };
 }
-// TODO: Is it better to implement or not to implement these methods?
+
 implUniformMethods! {
     len(&;) -> usize | 0,
     capacity(&;) -> usize | 0,
@@ -317,7 +322,7 @@ implUniformMethods! {
     clear(&,mut;) | (),
     is_empty(&;) -> bool | true,
     dedup(&,mut;) | (),
-    swap(&,mut; a: usize, b: usize) | panic!("Tried to swap on an empty list with. {a}<->{b}"),
+    swap(&,mut; a: usize, b: usize) | panic!("Tried to swap on an empty list with {a}<->{b}"),
     reverse(&,mut;) | (),
     rotate_left(&,mut; mid: usize) | if mid > 0 { panic!("Tried to rotate an empty list") },
     rotate_right(&,mut; k: usize) | if k > 0 { panic!("Tried to rotate an empty list") }

--- a/src/nbt/list.rs
+++ b/src/nbt/list.rs
@@ -138,14 +138,15 @@ impl NbtList {
 
     /// Unpacks this list and converts it into a "heterogeneous" list of items
     /// wrapped in NbtCompounds like so: `{"": <element}`.
-    /// 
+    ///
     /// This operation will always wrap the list __even if it is already a wrapped list__!
     /// If you only want to ensure your list is "heterogeneous", use [NbtList::ensure_wrapped].
     pub fn into_wrapped(self) -> Vec<NbtCompound> {
         nbt_list_call_uniform!(
             self,
             content,
-            content.into_iter()
+            content
+                .into_iter()
                 .map(|element| NbtCompound {
                     child_tags: vec![(String::new(), element.into_tag())]
                 })
@@ -158,7 +159,7 @@ impl NbtList {
     ///
     /// More formally, this method checks whether the list is currently wrapped.
     /// If it is not, it calls [NbtList::into_wrapped] and replaces this list with the result.
-    /// 
+    ///
     /// Returns a mutable reference to the contents of `self`, after potentially having wrapped its prior contents.
     pub fn ensure_wrapped(&mut self) -> &mut Vec<NbtCompound> {
         if !self.is_wrapped() {
@@ -166,12 +167,12 @@ impl NbtList {
         }
         match self {
             NbtList::Compound(x) => x,
-            _ => unreachable!("list must be a compound list")
+            _ => unreachable!("list must be a compound list"),
         }
     }
 
     /// Checks whether this list is a wrapped list.
-    /// 
+    ///
     /// A list is considered wrapped, if its children are [NbtCompound]s
     /// with only one element, whose key is the empty string.
     /// This is the serialised result of heterogeneous lists in SNBT.
@@ -179,13 +180,12 @@ impl NbtList {
         match self {
             Self::Compound(contents) => {
                 // TODO: This check is probably too expensive for real-world use.
-                contents.iter()
-                    .all(|compound| {
-                        let tags = &compound.child_tags;
-                        tags.len() == 1 && tags[0].0.is_empty()
-                    })
-            },
-            _ => false
+                contents.iter().all(|compound| {
+                    let tags = &compound.child_tags;
+                    tags.len() == 1 && tags[0].0.is_empty()
+                })
+            }
+            _ => false,
         }
     }
 

--- a/src/nbt/list.rs
+++ b/src/nbt/list.rs
@@ -136,6 +136,59 @@ impl NbtList {
         self.into_iter()
     }
 
+    /// Unpacks this list and converts it into a "heterogeneous" list of items
+    /// wrapped in NbtCompounds like so: `{"": <element}`.
+    /// 
+    /// This operation will always wrap the list __even if it is already a wrapped list__!
+    /// If you only want to ensure your list is "heterogeneous", use [NbtList::ensure_wrapped].
+    pub fn into_wrapped(self) -> Vec<NbtCompound> {
+        nbt_list_call_uniform!(
+            self,
+            content,
+            content.into_iter()
+                .map(|element| NbtCompound {
+                    child_tags: vec![(String::new(), element.into_tag())]
+                })
+                .collect(),
+            vec![]
+        )
+    }
+
+    /// Ensures that this list is a wrapped list, if it wasn't already.
+    ///
+    /// More formally, this method checks whether the list is currently wrapped.
+    /// If it is not, it calls [NbtList::into_wrapped] and replaces this list with the result.
+    /// 
+    /// Returns a mutable reference to the contents of `self`, after potentially having wrapped its prior contents.
+    pub fn ensure_wrapped(&mut self) -> &mut Vec<NbtCompound> {
+        if !self.is_wrapped() {
+            *self = NbtList::Compound(std::mem::take(self).into_wrapped());
+        }
+        match self {
+            NbtList::Compound(x) => x,
+            _ => unreachable!("list must be a compound list")
+        }
+    }
+
+    /// Checks whether this list is a wrapped list.
+    /// 
+    /// A list is considered wrapped, if its children are [NbtCompound]s
+    /// with only one element, whose key is the empty string.
+    /// This is the serialised result of heterogeneous lists in SNBT.
+    pub fn is_wrapped(&self) -> bool {
+        match self {
+            Self::Compound(contents) => {
+                // TODO: This check is probably too expensive for real-world use.
+                contents.iter()
+                    .all(|compound| {
+                        let tags = &compound.child_tags;
+                        tags.len() == 1 && tags[0].0.is_empty()
+                    })
+            },
+            _ => false
+        }
+    }
+
     fn deser_list_helper<T: PrivateNbtCompatible>(
         bytes: &mut impl Buf,
         len: usize,

--- a/src/nbt/list.rs
+++ b/src/nbt/list.rs
@@ -20,31 +20,60 @@ use crate::{
     NbtCompound,
 };
 
-macro_rules! call_uniform {
-    // cursed function call signature, but what can you do
-    (($self:ident,$method:path[$($parameter:tt),*]), $end_case:expr) => {
+/// Helper macro to generate match cases to run code on the contents of an [NbtList].
+///
+/// Has two formats: Expression mode and Method mode.
+/// - Expression mode is the most powerful, and can be used to execute
+///   any expression on the content of the list, potentially returning a value.
+/// - Method mode is specifically for executing [Vec] methods
+///   (and methods of any type [Vec] [std::ops::Deref]s to).
+///
+/// ```
+/// use crab_nbt::NbtList;
+/// use crab_nbt::nbt_list_call_uniform;
+/// let mut nbt_list = NbtList::Short(vec![1,2,3]);
+/// // Expression mode
+/// nbt_list_call_uniform!(
+///     // may be any expression resulting in an NbtList or a borrowed form of it.
+///     &mut nbt_list,
+///     content,
+///     content.push(Default::default()),
+///     panic!("Cannot push default to an empty list")
+/// );
+/// assert_eq!(nbt_list, NbtList::Short(vec![1,2,3,0]));
+///
+/// // Method mode
+/// // (note that this particular use case is already supported via NbtList::len)
+/// assert_eq!(
+///     nbt_list_call_uniform!((nbt_list.len()), 0),
+///     4
+/// );
+/// ```
+#[macro_export]
+macro_rules! nbt_list_call_uniform {
+    ($self:expr,$content:ident, $expression:expr, $end_case:expr) => {
         {
-            use self::NbtList::*;
+            use $crate::NbtList::*;
             match $self {
                 End => $end_case,
-                Byte(x) => $method(x,$($parameter),*),
-                Short(x) => $method(x,$($parameter),*),
-                Int(x) => $method(x,$($parameter),*),
-                Long(x) => $method(x,$($parameter),*),
-                Float(x) => $method(x,$($parameter),*),
-                Double(x) => $method(x,$($parameter),*),
-                ByteArray(x) => $method(x,$($parameter),*),
-                String(x) => $method(x,$($parameter),*),
-                List(x) => $method(x,$($parameter),*),
-                Compound(x) => $method(x,$($parameter),*),
-                IntArray(x) => $method(x,$($parameter),*),
-                LongArray(x) => $method(x,$($parameter),*),
+                Byte($content) => $expression,
+                Short($content) => $expression,
+                Int($content) => $expression,
+                Long($content) => $expression,
+                Float($content) => $expression,
+                Double($content) => $expression,
+                ByteArray($content) => $expression,
+                String($content) => $expression,
+                List($content) => $expression,
+                Compound($content) => $expression,
+                IntArray($content) => $expression,
+                LongArray($content) => $expression,
             }
         }
     };
     (($self:ident.$($expression:tt)+), $end_case:expr) => {
         {
-            use self::NbtList::*;
+            use $crate::NbtList::*;
             match $self {
                 End => $end_case,
                 Byte(x) => x.$($expression)*,
@@ -64,9 +93,10 @@ macro_rules! call_uniform {
     };
 }
 
-#[derive(Clone, Debug, PartialEq, From, TryInto)]
+#[derive(Default, Clone, Debug, PartialEq, From, TryInto)]
 #[repr(u8)]
 pub enum NbtList {
+    #[default]
     End = END_ID,
     Byte(Vec<i8>) = BYTE_ID,
     Short(Vec<i16>) = SHORT_ID,
@@ -82,7 +112,7 @@ pub enum NbtList {
     LongArray(Vec<Vec<i64>>) = LONG_ARRAY_ID,
 }
 impl NbtList {
-    pub fn get_type_id(&self) -> u8 {
+    pub fn get_content_type_id(&self) -> u8 {
         use self::NbtList::*;
         match self {
             End => END_ID,
@@ -102,11 +132,11 @@ impl NbtList {
     }
 
     pub fn get(&self, index: usize) -> Option<&dyn NbtCompatible> {
-        call_uniform!((self.get(index).map(|x| x as &dyn NbtCompatible)), None)
+        nbt_list_call_uniform!((self.get(index).map(|x| x as &dyn NbtCompatible)), None)
     }
 
     pub fn get_mut(&mut self, index: usize) -> Option<&mut dyn NbtCompatible> {
-        call_uniform!(
+        nbt_list_call_uniform!(
             (self.get_mut(index).map(|x| x as &mut dyn NbtCompatible)),
             None
         )
@@ -150,7 +180,7 @@ impl Index<usize> for NbtList {
     type Output = dyn NbtCompatible;
 
     fn index(&self, index: usize) -> &Self::Output {
-        call_uniform!(
+        nbt_list_call_uniform!(
             (self.index(index)),
             panic!("Index out of bounds for empty list. Index {index}")
         )
@@ -158,7 +188,7 @@ impl Index<usize> for NbtList {
 }
 impl IndexMut<usize> for NbtList {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        call_uniform!(
+        nbt_list_call_uniform!(
             (self.index_mut(index)),
             panic!("Index out of bounds for empty list. Index {index}")
         )
@@ -199,7 +229,7 @@ impl Ord for NbtList {
             (Self::Compound(a), Self::Compound(b)) => a.cmp(b),
             (Self::IntArray(a), Self::IntArray(b)) => a.cmp(b),
             (Self::LongArray(a), Self::LongArray(b)) => a.cmp(b),
-            _ => self.get_type_id().cmp(&other.get_type_id()),
+            _ => self.get_content_type_id().cmp(&other.get_content_type_id()),
         }
     }
 }
@@ -242,7 +272,7 @@ impl PrivateNbtCompatible for NbtList {
     where
         Self: Sized,
     {
-        call_uniform!((self, NbtList::ser_list_helper[bytes]), {
+        nbt_list_call_uniform!(self, content, NbtList::ser_list_helper(content, bytes), {
             bytes.put_u8(ids::END_ID);
             bytes.put_i32(0);
         })

--- a/src/nbt/list.rs
+++ b/src/nbt/list.rs
@@ -103,7 +103,7 @@ impl NbtList {
         call_uniform!((self.get(index).map(|x| x as &dyn NbtCompatible)), None)
     }
 
-    pub fn get_mut<'a>(&'a mut self, index: usize) -> Option<&'a mut dyn NbtCompatible> {
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut dyn NbtCompatible> {
         call_uniform!(
             (self.get_mut(index).map(|x| x as &mut dyn NbtCompatible)),
             None

--- a/src/nbt/list.rs
+++ b/src/nbt/list.rs
@@ -1,11 +1,45 @@
-use std::{fmt::Display, ops::{Index, IndexMut}};
+use std::{
+    fmt::Display,
+    ops::{Index, IndexMut},
+};
 
-use bytes::Bytes;
+use bytes::{Buf, BufMut, Bytes};
 use derive_more::{From, TryInto};
 
-use crate::{NbtCompound, nbt::{nbt_trait::NbtCompatible, utils::{ids::*, write_listlike}}};
+use crate::{
+    error::Error,
+    nbt::{
+        nbt_trait::{NbtCompatible, PrivateNbtCompatible},
+        utils::{
+            ids::{self, *},
+            write_listlike,
+        },
+    },
+    NbtCompound,
+};
 
 macro_rules! call_uniform {
+    // cursed function call signature, but what can you do
+    (($self:ident,$method:path[$($parameter:tt),*]), $end_case:expr) => {
+        {
+            use self::NbtList::*;
+            match $self {
+                End => $end_case,
+                Byte(x) => $method(x,$($parameter),*),
+                Short(x) => $method(x,$($parameter),*),
+                Int(x) => $method(x,$($parameter),*),
+                Long(x) => $method(x,$($parameter),*),
+                Float(x) => $method(x,$($parameter),*),
+                Double(x) => $method(x,$($parameter),*),
+                ByteArray(x) => $method(x,$($parameter),*),
+                String(x) => $method(x,$($parameter),*),
+                List(x) => $method(x,$($parameter),*),
+                Compound(x) => $method(x,$($parameter),*),
+                IntArray(x) => $method(x,$($parameter),*),
+                LongArray(x) => $method(x,$($parameter),*),
+            }
+        }
+    };
     (($self:ident.$($expression:tt)+), $end_case:expr) => {
         {
             use self::NbtList::*;
@@ -31,9 +65,6 @@ macro_rules! call_uniform {
 #[derive(Clone, Debug, PartialEq, PartialOrd, From, TryInto)]
 #[repr(u8)]
 pub enum NbtList {
-    // TODO: Everything about End.
-    //  This is needed because an empty list serializes to a list of type END_TAG
-    //  Need to check how this can be treated in various applications
     End = END_ID,
     Byte(Vec<i8>) = BYTE_ID,
     Short(Vec<i16>) = SHORT_ID,
@@ -59,12 +90,12 @@ impl NbtList {
             Long(_) => LONG_ID,
             Float(_) => FLOAT_ID,
             Double(_) => DOUBLE_ID,
-            ByteArray(_)  => BYTE_ARRAY_ID,
+            ByteArray(_) => BYTE_ARRAY_ID,
             String(_) => STRING_ID,
             List(_) => LIST_ID,
             Compound(_) => COMPOUND_ID,
             IntArray(_) => INT_ARRAY_ID,
-            LongArray(_) => LONG_ARRAY_ID
+            LongArray(_) => LONG_ARRAY_ID,
         }
     }
 
@@ -72,8 +103,11 @@ impl NbtList {
         call_uniform!((self.get(index).map(|x| x as &dyn NbtCompatible)), None)
     }
 
-    pub fn get_mut<'a>(&'a mut self, index: usize) -> Option<&'a mut dyn NbtCompatible > {
-        call_uniform!((self.get_mut(index).map(|x| x as &mut dyn NbtCompatible)), None)
+    pub fn get_mut<'a>(&'a mut self, index: usize) -> Option<&'a mut dyn NbtCompatible> {
+        call_uniform!(
+            (self.get_mut(index).map(|x| x as &mut dyn NbtCompatible)),
+            None
+        )
     }
 
     pub fn iter(&self) -> Iter<'_> {
@@ -83,18 +117,49 @@ impl NbtList {
     pub fn iter_mut(&mut self) -> IterMut<'_> {
         self.into_iter()
     }
+
+    fn deser_list_helper<T: PrivateNbtCompatible>(
+        bytes: &mut impl Buf,
+        len: usize,
+        wrapper: impl FnOnce(Vec<T>) -> NbtList,
+    ) -> Result<NbtList, Error> {
+        let mut list = Vec::with_capacity(len);
+        for _ in 0..len {
+            list.push(T::deserialize_data(bytes)?);
+        }
+        Ok(wrapper(list))
+    }
+
+    fn ser_list_helper<T: PrivateNbtCompatible>(inner: &Vec<T>, bytes: &mut impl BufMut) {
+        if inner.is_empty() {
+            bytes.put_u8(ids::END_ID);
+            bytes.put_i32(0);
+        } else {
+            bytes.put_u8(T::get_id());
+            bytes.put_i32(inner.len() as i32);
+            for element in inner.iter() {
+                element.serialize_data(bytes);
+            }
+        }
+    }
 }
-// Slice indexes are impossible on erased vecs, because there is no uniform output type
+// Slices are impossible on erased vecs, because there is no uniform output type
 impl Index<usize> for NbtList {
     type Output = dyn NbtCompatible;
 
     fn index(&self, index: usize) -> &Self::Output {
-        call_uniform!((self.index(index)), panic!("Index out of bounds for empty list. Index {index}"))
+        call_uniform!(
+            (self.index(index)),
+            panic!("Index out of bounds for empty list. Index {index}")
+        )
     }
 }
 impl IndexMut<usize> for NbtList {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        call_uniform!((self.index_mut(index)), panic!("Index out of bounds for empty list. Index {index}"))
+        call_uniform!(
+            (self.index_mut(index)),
+            panic!("Index out of bounds for empty list. Index {index}")
+        )
     }
 }
 impl<'a> IntoIterator for &'a NbtList {
@@ -113,6 +178,57 @@ impl<'a> IntoIterator for &'a mut NbtList {
 
     fn into_iter(self) -> Self::IntoIter {
         Self::IntoIter::new(self)
+    }
+}
+
+impl PrivateNbtCompatible for NbtList {
+    fn deserialize_data(bytes: &mut impl Buf) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        let tag_type_id = bytes.try_get_u8()?;
+        let len = bytes.try_get_i32()?;
+        match tag_type_id {
+            ids::END_ID => Ok(NbtList::End),
+            ids::BYTE_ID => NbtList::deser_list_helper(bytes, len as usize, NbtList::Byte),
+            ids::SHORT_ID => NbtList::deser_list_helper(bytes, len as usize, NbtList::Short),
+            ids::INT_ID => NbtList::deser_list_helper(bytes, len as usize, NbtList::Int),
+            ids::LONG_ID => NbtList::deser_list_helper(bytes, len as usize, NbtList::Long),
+            ids::FLOAT_ID => NbtList::deser_list_helper(bytes, len as usize, NbtList::Float),
+            ids::DOUBLE_ID => NbtList::deser_list_helper(bytes, len as usize, NbtList::Double),
+            ids::BYTE_ARRAY_ID => {
+                NbtList::deser_list_helper(bytes, len as usize, NbtList::ByteArray)
+            }
+            ids::STRING_ID => NbtList::deser_list_helper(bytes, len as usize, NbtList::String),
+            ids::LIST_ID => NbtList::deser_list_helper(bytes, len as usize, NbtList::List),
+            ids::COMPOUND_ID => NbtList::deser_list_helper(bytes, len as usize, NbtList::Compound),
+            ids::INT_ARRAY_ID => NbtList::deser_list_helper(bytes, len as usize, NbtList::IntArray),
+            ids::LONG_ARRAY_ID => {
+                NbtList::deser_list_helper(bytes, len as usize, NbtList::LongArray)
+            }
+            _ => Err(Error::UnknownTagId(tag_type_id)),
+        }
+    }
+
+    fn serialize_data(&self, bytes: &mut impl bytes::BufMut)
+    where
+        Self: Sized,
+    {
+        call_uniform!((self, NbtList::ser_list_helper[bytes]), {
+            bytes.put_u8(ids::END_ID);
+            bytes.put_i32(0);
+        })
+    }
+
+    fn write_snbt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write_listlike(f, "", "", self.iter().map(|el| el.snbt_dyn()))
+    }
+
+    fn get_id() -> u8
+    where
+        Self: Sized,
+    {
+        ids::LIST_ID
     }
 }
 impl Display for NbtList {
@@ -205,7 +321,6 @@ implUniformMethods! {
     reverse(&,mut;) | (),
     rotate_left(&,mut; mid: usize) | if mid > 0 { panic!("Tried to rotate an empty list") },
     rotate_right(&,mut; k: usize) | if k > 0 { panic!("Tried to rotate an empty list") }
-    
 }
 
 impl_TryAsRefAndMut! {
@@ -225,11 +340,14 @@ impl_TryAsRefAndMut! {
 
 pub struct Iter<'a> {
     list: &'a NbtList,
-    index: Option<usize>
+    index: Option<usize>,
 }
 impl<'a> Iter<'a> {
     fn new(list: &'a NbtList) -> Self {
-        Self { list, index: Some(0) }
+        Self {
+            list,
+            index: Some(0),
+        }
     }
 }
 impl<'a> Iterator for Iter<'a> {
@@ -249,11 +367,14 @@ impl<'a> Iterator for Iter<'a> {
 
 pub struct IterMut<'a> {
     list: &'a mut NbtList,
-    index: Option<usize>
+    index: Option<usize>,
 }
 impl<'a> IterMut<'a> {
     fn new(list: &'a mut NbtList) -> Self {
-        Self { list, index: Some(0) }
+        Self {
+            list,
+            index: Some(0),
+        }
     }
 }
 impl<'a> Iterator for IterMut<'a> {
@@ -261,7 +382,9 @@ impl<'a> Iterator for IterMut<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let index = self.index?;
-        let val: Option<&'a mut dyn NbtCompatible> = self.list.get_mut(index)
+        let val: Option<&'a mut dyn NbtCompatible> = self
+            .list
+            .get_mut(index)
             // The borrow checker is being too eager with get_mut and degrades lifetime 'a to the lifetime of self.
             // For reasons unknown to me this only happens with mutable pointers.
             // Other methods of lifetime expansion (such as pointer casting) have proven unsuccessful, so transmute is used as a last resort.

--- a/src/nbt/list.rs
+++ b/src/nbt/list.rs
@@ -94,6 +94,7 @@ macro_rules! nbt_list_call_uniform {
 }
 
 #[derive(Default, Clone, Debug, PartialEq, From, TryInto)]
+#[try_into(owned, ref, ref_mut)]
 #[repr(u8)]
 pub enum NbtList {
     #[default]
@@ -296,49 +297,6 @@ impl Display for NbtList {
     }
 }
 
-macro_rules! impl_TryAsRefAndMut {
-    // empty lists are always serialized as lists of type TAG_END in NBT
-    // such a list could have any type, so all TryAsRef and TryAsMut calls must succeed on it.
-    // to ensure that no behaviour changes occur between reloading of a list, any TryAsRef and TryAsMut on empty lists succeeds.
-    ($(($variant:ident, $type:ty)),+) => {
-        use crate::{TryAsRef, TryAsMut};
-        $(
-            impl TryAsRef<Vec<$type>> for NbtList {
-                fn try_as_ref(&self) -> Option<&Vec<$type>> {
-                    static EMPTY_VEC: Vec<$type> = Vec::new();
-                    match self {
-                        Self::$variant(x) => Some(x),
-                        _ => {
-                            if self.is_empty() {
-                                Some(&EMPTY_VEC)
-                            } else {
-                                None
-                            }
-                        }
-                    }
-                }
-            }
-            impl TryAsMut<Vec<$type>> for NbtList {
-                fn try_as_mut(&mut self) -> Option<&mut Vec<$type>> {
-                    match self {
-                        Self::$variant(x) => Some(x),
-                        _ => {
-                            if self.is_empty() {
-                                *self = Self::$variant(Vec::new());
-                                match self {
-                                    Self::$variant(x) => Some(x),
-                                    _ => unreachable!()
-                                }
-                            } else {
-                                None
-                            }
-                        }
-                    }
-                }
-            }
-        )+
-    };
-}
 /// Implements [`Vec`] methods on the NbtList by delegating the method call.
 /// Can only be used on methods whose signature is independent of the list type.
 ///
@@ -384,21 +342,6 @@ implUniformMethods! {
     reverse(&,mut;) | (),
     rotate_left(&,mut; mid: usize) | if mid > 0 { panic!("Tried to rotate an empty list") },
     rotate_right(&,mut; k: usize) | if k > 0 { panic!("Tried to rotate an empty list") }
-}
-
-impl_TryAsRefAndMut! {
-    (Byte, i8),
-    (Short, i16),
-    (Int, i32),
-    (Long, i64),
-    (Float, f32),
-    (Double, f64),
-    (ByteArray, Bytes),
-    (String, String),
-    (List, NbtList),
-    (Compound, NbtCompound),
-    (IntArray, Vec<i32>),
-    (LongArray, Vec<i64>)
 }
 
 pub struct Iter<'a> {

--- a/src/nbt/nbt_trait.rs
+++ b/src/nbt/nbt_trait.rs
@@ -1,7 +1,9 @@
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
 use as_any::AsAny;
 use bytes::{Buf, BufMut, Bytes};
 
-use crate::{NbtCompound, NbtTag, TryAsMut, TryAsRef, nbt::{list::NbtList, utils::ids::*}};
+use crate::{NbtCompound, NbtTag, TryAsMut, TryAsRef, nbt::{list::NbtList, utils::{escape_string_value, ids::*, write_listlike}}};
 
 /// Implements behaviour for nbt-datatypes that should not be exposed outside the library.
 /// Usually this is serialisation behaviour and dynamic dispatches used throughout the library.
@@ -9,12 +11,24 @@ pub(crate) trait PrivateNbtCompatible: AsAny {
     // fn deserialize(bytes: &mut impl Buf) where Self: Sized;
     // // TODO: Fix dyn-incompatibility caused by this generic method.
     // fn serialize(&self, bytes: &mut impl BufMut) where Self: Sized;
+
+    fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult;
 }
-impl<T: 'static> PrivateNbtCompatible for T { }
 
 pub trait NbtCompatible: PrivateNbtCompatible {
     fn get_type_id(&self) -> u8;
+    fn snbt(&self) -> SnbtDisplay<Self> where Self: Sized {
+        SnbtDisplay(self)
+    }
+
     fn as_tag(self) -> NbtTag;
+}
+impl dyn NbtCompatible {
+    // This method cannot be named "snbt" due to rustc falsely claiming
+    // method ambiguity with NbtCompatible::snbt, which requires Self: Sized
+    pub fn snbt_dyn(&self) -> SnbtDisplay<dyn NbtCompatible> {
+        SnbtDisplay(self)
+    }
 }
 impl<T: NbtCompatible> TryAsRef<T> for dyn NbtCompatible {
     fn try_as_ref(&self) -> Option<&T> {
@@ -42,6 +56,70 @@ macro_rules! impl_NbtCompatible {
         )+
     };
 }
+
+impl PrivateNbtCompatible for i8 {
+    fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{self}b")
+    }
+}
+impl PrivateNbtCompatible for i16 {
+    fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{self}s")
+    }
+}
+impl PrivateNbtCompatible for i32 {
+    fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{self}")
+    }
+}
+impl PrivateNbtCompatible for i64 {
+    fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{self}L")
+    }
+}
+impl PrivateNbtCompatible for f32 {
+    fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        // using debug here matches Minecraft on whole numbers (3.0 instead of 3)
+        write!(f, "{self:?}f")
+    }
+}
+impl PrivateNbtCompatible for f64 {
+    fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        // using debug here matches Minecraft on whole numbers (3.0 instead of 3)
+        write!(f, "{self:?}d")
+    }
+}
+impl PrivateNbtCompatible for Bytes {
+    fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write_listlike(f, "B; ", "B", self.iter().map(|b| *b as i8))
+    }
+}
+impl PrivateNbtCompatible for String {
+    fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{}", escape_string_value(self))
+    }
+}
+impl PrivateNbtCompatible for NbtList {
+    fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{self}")
+    }
+}
+impl PrivateNbtCompatible for NbtCompound {
+    fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{self}")
+    }
+}
+impl PrivateNbtCompatible for Vec<i32> {
+    fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write_listlike(f, "I; ", "", self)
+    }
+}
+impl PrivateNbtCompatible for Vec<i64> {
+    fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write_listlike(f, "L; ", "L", self)
+    }
+}
+
 impl_NbtCompatible! {
     i8 => BYTE_ID, NbtTag::Byte,
     i16 => SHORT_ID, NbtTag::Short,
@@ -55,4 +133,12 @@ impl_NbtCompatible! {
     NbtCompound => COMPOUND_ID, NbtTag::Compound,
     Vec<i32> => INT_ARRAY_ID, NbtTag::IntArray,
     Vec<i64> => LONG_ARRAY_ID, NbtTag::LongArray
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SnbtDisplay<'a, T: NbtCompatible + PrivateNbtCompatible + ?Sized>(pub &'a T);
+impl<'a, T: NbtCompatible + ?Sized + PrivateNbtCompatible> Display for SnbtDisplay<'a, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        self.0.write_snbt(f)
+    }
 }

--- a/src/nbt/nbt_trait.rs
+++ b/src/nbt/nbt_trait.rs
@@ -1,0 +1,58 @@
+use as_any::AsAny;
+use bytes::{Buf, BufMut, Bytes};
+
+use crate::{NbtCompound, NbtTag, TryAsMut, TryAsRef, nbt::{list::NbtList, utils::ids::*}};
+
+/// Implements behaviour for nbt-datatypes that should not be exposed outside the library.
+/// Usually this is serialisation behaviour and dynamic dispatches used throughout the library.
+pub(crate) trait PrivateNbtCompatible: AsAny {
+    // fn deserialize(bytes: &mut impl Buf) where Self: Sized;
+    // // TODO: Fix dyn-incompatibility caused by this generic method.
+    // fn serialize(&self, bytes: &mut impl BufMut) where Self: Sized;
+}
+impl<T: 'static> PrivateNbtCompatible for T { }
+
+pub trait NbtCompatible: PrivateNbtCompatible {
+    fn get_type_id(&self) -> u8;
+    fn as_tag(self) -> NbtTag;
+}
+impl<T: NbtCompatible> TryAsRef<T> for dyn NbtCompatible {
+    fn try_as_ref(&self) -> Option<&T> {
+        self.as_any().downcast_ref()
+    }
+}
+impl<T: NbtCompatible> TryAsMut<T> for dyn NbtCompatible {
+    fn try_as_mut(&mut self) -> Option<&mut T> {
+        self.as_any_mut().downcast_mut()
+    }
+}
+
+macro_rules! impl_NbtCompatible {
+    ($($type:ty => $type_id:expr, $wrapper:expr),+) => {
+        $(
+            impl NbtCompatible for $type {
+                fn get_type_id(&self) -> u8 {
+                    $type_id
+                }
+
+                fn as_tag(self) -> NbtTag {
+                    $wrapper(self)
+                }
+            }
+        )+
+    };
+}
+impl_NbtCompatible! {
+    i8 => BYTE_ID, NbtTag::Byte,
+    i16 => SHORT_ID, NbtTag::Short,
+    i32 => INT_ID, NbtTag::Int,
+    i64 => LONG_ID, NbtTag::Long,
+    f32 => FLOAT_ID, NbtTag::Float,
+    f64 => DOUBLE_ID, NbtTag::Double,
+    Bytes => BYTE_ARRAY_ID, NbtTag::ByteArray,
+    String => STRING_ID, NbtTag::String,
+    NbtList => LIST_ID, NbtTag::List,
+    NbtCompound => COMPOUND_ID, NbtTag::Compound,
+    Vec<i32> => INT_ARRAY_ID, NbtTag::IntArray,
+    Vec<i64> => LONG_ARRAY_ID, NbtTag::LongArray
+}

--- a/src/nbt/nbt_trait.rs
+++ b/src/nbt/nbt_trait.rs
@@ -42,7 +42,7 @@ pub trait NbtCompatible: PrivateNbtCompatible {
         SnbtDisplay(self)
     }
 
-    fn as_tag(self) -> NbtTag;
+    fn into_tag(self) -> NbtTag;
 }
 impl dyn NbtCompatible {
     // This method cannot be named "snbt" due to rustc falsely claiming
@@ -70,7 +70,7 @@ macro_rules! impl_NbtCompatible {
                     <$type>::get_id()
                 }
 
-                fn as_tag(self) -> NbtTag {
+                fn into_tag(self) -> NbtTag {
                     $wrapper(self)
                 }
             }

--- a/src/nbt/nbt_trait.rs
+++ b/src/nbt/nbt_trait.rs
@@ -9,7 +9,7 @@ use crate::{
         list::NbtList,
         utils::{escape_string_value, get_nbt_string, ids::*, read_array, write_listlike},
     },
-    NbtCompound, NbtTag, TryAsMut, TryAsRef,
+    NbtCompound, NbtTag
 };
 
 /// Implements behaviour for nbt-datatypes that should not be exposed outside the library.
@@ -50,15 +50,13 @@ impl dyn NbtCompatible {
     pub fn snbt_dyn(&self) -> SnbtDisplay<'_, dyn NbtCompatible> {
         SnbtDisplay(self)
     }
-}
-impl<T: NbtCompatible> TryAsRef<T> for dyn NbtCompatible {
-    fn try_as_ref(&self) -> Option<&T> {
+
+    pub fn as_concrete<T: NbtCompatible>(&self) -> Option<&T> {
         self.as_any().downcast_ref()
     }
-}
-impl<T: NbtCompatible> TryAsMut<T> for dyn NbtCompatible {
-    fn try_as_mut(&mut self) -> Option<&mut T> {
-        self.as_any_mut().downcast_mut()
+
+    pub fn as_concrete_mut<T: NbtCompatible>(&mut self) -> Option<&mut T> {
+       self.as_any_mut().downcast_mut()
     }
 }
 

--- a/src/nbt/nbt_trait.rs
+++ b/src/nbt/nbt_trait.rs
@@ -47,6 +47,7 @@ pub trait NbtCompatible: PrivateNbtCompatible {
 impl dyn NbtCompatible {
     // This method cannot be named "snbt" due to rustc falsely claiming
     // method ambiguity with NbtCompatible::snbt, which requires Self: Sized
+    // (we also can't remove that bound because the return value uses Self)
     pub fn snbt_dyn(&self) -> SnbtDisplay<'_, dyn NbtCompatible> {
         SnbtDisplay(self)
     }

--- a/src/nbt/nbt_trait.rs
+++ b/src/nbt/nbt_trait.rs
@@ -9,7 +9,7 @@ use crate::{
         list::NbtList,
         utils::{escape_string_value, get_nbt_string, ids::*, read_array, write_listlike},
     },
-    NbtCompound, NbtTag
+    NbtCompound, NbtTag,
 };
 
 /// Implements behaviour for nbt-datatypes that should not be exposed outside the library.
@@ -57,7 +57,7 @@ impl dyn NbtCompatible {
     }
 
     pub fn as_concrete_mut<T: NbtCompatible>(&mut self) -> Option<&mut T> {
-       self.as_any_mut().downcast_mut()
+        self.as_any_mut().downcast_mut()
     }
 }
 

--- a/src/nbt/nbt_trait.rs
+++ b/src/nbt/nbt_trait.rs
@@ -3,21 +3,42 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 use as_any::AsAny;
 use bytes::{Buf, BufMut, Bytes};
 
-use crate::{NbtCompound, NbtTag, TryAsMut, TryAsRef, nbt::{list::NbtList, utils::{escape_string_value, ids::*, write_listlike}}};
+use crate::{
+    error::Error,
+    nbt::{
+        list::NbtList,
+        utils::{escape_string_value, get_nbt_string, ids::*, read_array, write_listlike},
+    },
+    NbtCompound, NbtTag, TryAsMut, TryAsRef,
+};
 
 /// Implements behaviour for nbt-datatypes that should not be exposed outside the library.
 /// Usually this is serialisation behaviour and dynamic dispatches used throughout the library.
 pub(crate) trait PrivateNbtCompatible: AsAny {
-    // fn deserialize(bytes: &mut impl Buf) where Self: Sized;
-    // // TODO: Fix dyn-incompatibility caused by this generic method.
-    // fn serialize(&self, bytes: &mut impl BufMut) where Self: Sized;
+    fn get_id() -> u8
+    where
+        Self: Sized;
+
+    /// Read the contents of the tag out of the buffer and constructs a new instance of self.
+    /// The tag id has already been read at this point
+    fn deserialize_data(bytes: &mut impl Buf) -> Result<Self, Error>
+    where
+        Self: Sized;
+    /// Serialize self into bytes, excluding the tag id
+    fn serialize_data(&self, bytes: &mut impl BufMut)
+    where
+        Self: Sized;
 
     fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult;
 }
 
+#[allow(private_bounds)]
 pub trait NbtCompatible: PrivateNbtCompatible {
     fn get_type_id(&self) -> u8;
-    fn snbt(&self) -> SnbtDisplay<Self> where Self: Sized {
+    fn snbt(&self) -> SnbtDisplay<'_, Self>
+    where
+        Self: Sized,
+    {
         SnbtDisplay(self)
     }
 
@@ -26,7 +47,7 @@ pub trait NbtCompatible: PrivateNbtCompatible {
 impl dyn NbtCompatible {
     // This method cannot be named "snbt" due to rustc falsely claiming
     // method ambiguity with NbtCompatible::snbt, which requires Self: Sized
-    pub fn snbt_dyn(&self) -> SnbtDisplay<dyn NbtCompatible> {
+    pub fn snbt_dyn(&self) -> SnbtDisplay<'_, dyn NbtCompatible> {
         SnbtDisplay(self)
     }
 }
@@ -42,11 +63,11 @@ impl<T: NbtCompatible> TryAsMut<T> for dyn NbtCompatible {
 }
 
 macro_rules! impl_NbtCompatible {
-    ($($type:ty => $type_id:expr, $wrapper:expr),+) => {
+    ($($type:ty => $wrapper:expr),+) => {
         $(
             impl NbtCompatible for $type {
                 fn get_type_id(&self) -> u8 {
-                    $type_id
+                    <$type>::get_id()
                 }
 
                 fn as_tag(self) -> NbtTag {
@@ -61,20 +82,104 @@ impl PrivateNbtCompatible for i8 {
     fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{self}b")
     }
+
+    fn deserialize_data(bytes: &mut impl Buf) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        Ok(bytes.try_get_i8()?)
+    }
+
+    fn serialize_data(&self, bytes: &mut impl BufMut)
+    where
+        Self: Sized,
+    {
+        bytes.put_i8(*self)
+    }
+
+    fn get_id() -> u8
+    where
+        Self: Sized,
+    {
+        BYTE_ID
+    }
 }
 impl PrivateNbtCompatible for i16 {
     fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{self}s")
+    }
+
+    fn deserialize_data(bytes: &mut impl Buf) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        Ok(bytes.try_get_i16()?)
+    }
+
+    fn serialize_data(&self, bytes: &mut impl BufMut)
+    where
+        Self: Sized,
+    {
+        bytes.put_i16(*self)
+    }
+
+    fn get_id() -> u8
+    where
+        Self: Sized,
+    {
+        SHORT_ID
     }
 }
 impl PrivateNbtCompatible for i32 {
     fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{self}")
     }
+
+    fn deserialize_data(bytes: &mut impl Buf) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        Ok(bytes.try_get_i32()?)
+    }
+
+    fn serialize_data(&self, bytes: &mut impl BufMut)
+    where
+        Self: Sized,
+    {
+        bytes.put_i32(*self)
+    }
+
+    fn get_id() -> u8
+    where
+        Self: Sized,
+    {
+        INT_ID
+    }
 }
 impl PrivateNbtCompatible for i64 {
     fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{self}L")
+    }
+
+    fn deserialize_data(bytes: &mut impl Buf) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        Ok(bytes.try_get_i64()?)
+    }
+
+    fn serialize_data(&self, bytes: &mut impl BufMut)
+    where
+        Self: Sized,
+    {
+        bytes.put_i64(*self)
+    }
+
+    fn get_id() -> u8
+    where
+        Self: Sized,
+    {
+        LONG_ID
     }
 }
 impl PrivateNbtCompatible for f32 {
@@ -82,60 +187,196 @@ impl PrivateNbtCompatible for f32 {
         // using debug here matches Minecraft on whole numbers (3.0 instead of 3)
         write!(f, "{self:?}f")
     }
+
+    fn deserialize_data(bytes: &mut impl Buf) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        Ok(bytes.try_get_f32()?)
+    }
+
+    fn serialize_data(&self, bytes: &mut impl BufMut)
+    where
+        Self: Sized,
+    {
+        bytes.put_f32(*self)
+    }
+
+    fn get_id() -> u8
+    where
+        Self: Sized,
+    {
+        FLOAT_ID
+    }
 }
 impl PrivateNbtCompatible for f64 {
     fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
         // using debug here matches Minecraft on whole numbers (3.0 instead of 3)
         write!(f, "{self:?}d")
     }
+
+    fn deserialize_data(bytes: &mut impl Buf) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        Ok(bytes.try_get_f64()?)
+    }
+
+    fn serialize_data(&self, bytes: &mut impl BufMut)
+    where
+        Self: Sized,
+    {
+        bytes.put_f64(*self)
+    }
+
+    fn get_id() -> u8
+    where
+        Self: Sized,
+    {
+        DOUBLE_ID
+    }
 }
 impl PrivateNbtCompatible for Bytes {
     fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write_listlike(f, "B; ", "B", self.iter().map(|b| *b as i8))
+    }
+
+    fn deserialize_data(bytes: &mut impl Buf) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        let len = bytes.try_get_i32()? as usize;
+        let byte_array = bytes.copy_to_bytes(len);
+        Ok(byte_array)
+    }
+
+    fn serialize_data(&self, bytes: &mut impl BufMut)
+    where
+        Self: Sized,
+    {
+        bytes.put_i32(self.len() as i32);
+        bytes.put_slice(self);
+    }
+
+    fn get_id() -> u8
+    where
+        Self: Sized,
+    {
+        BYTE_ARRAY_ID
     }
 }
 impl PrivateNbtCompatible for String {
     fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{}", escape_string_value(self))
     }
-}
-impl PrivateNbtCompatible for NbtList {
-    fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{self}")
+
+    fn deserialize_data(bytes: &mut impl Buf) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        Ok(get_nbt_string(bytes).unwrap())
     }
-}
-impl PrivateNbtCompatible for NbtCompound {
-    fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{self}")
+
+    fn serialize_data(&self, bytes: &mut impl BufMut)
+    where
+        Self: Sized,
+    {
+        let java_string = simd_cesu8::encode(self);
+        bytes.put_u16(java_string.len() as u16);
+        bytes.put_slice(&java_string);
+    }
+
+    fn get_id() -> u8
+    where
+        Self: Sized,
+    {
+        STRING_ID
     }
 }
 impl PrivateNbtCompatible for Vec<i32> {
     fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write_listlike(f, "I; ", "", self)
     }
+
+    fn deserialize_data(bytes: &mut impl Buf) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        const BYTES: usize = size_of::<i32>();
+
+        let len = bytes.try_get_i32()? as usize;
+        let numbers = read_array::<i32, BYTES, _>(bytes, len, i32::from_be_bytes);
+        Ok(numbers)
+    }
+
+    fn serialize_data(&self, bytes: &mut impl BufMut)
+    where
+        Self: Sized,
+    {
+        bytes.put_i32(self.len() as i32);
+        for int in self {
+            bytes.put_i32(*int)
+        }
+    }
+
+    fn get_id() -> u8
+    where
+        Self: Sized,
+    {
+        INT_ARRAY_ID
+    }
 }
 impl PrivateNbtCompatible for Vec<i64> {
     fn write_snbt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write_listlike(f, "L; ", "L", self)
     }
+
+    fn deserialize_data(bytes: &mut impl Buf) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        const BYTES: usize = size_of::<i64>();
+
+        let len = bytes.try_get_i32()? as usize;
+        let numbers = read_array::<i64, BYTES, _>(bytes, len, i64::from_be_bytes);
+        Ok(numbers)
+    }
+
+    fn serialize_data(&self, bytes: &mut impl BufMut)
+    where
+        Self: Sized,
+    {
+        bytes.put_i32(self.len() as i32);
+        for long in self {
+            bytes.put_i64(*long)
+        }
+    }
+
+    fn get_id() -> u8
+    where
+        Self: Sized,
+    {
+        LONG_ARRAY_ID
+    }
 }
 
 impl_NbtCompatible! {
-    i8 => BYTE_ID, NbtTag::Byte,
-    i16 => SHORT_ID, NbtTag::Short,
-    i32 => INT_ID, NbtTag::Int,
-    i64 => LONG_ID, NbtTag::Long,
-    f32 => FLOAT_ID, NbtTag::Float,
-    f64 => DOUBLE_ID, NbtTag::Double,
-    Bytes => BYTE_ARRAY_ID, NbtTag::ByteArray,
-    String => STRING_ID, NbtTag::String,
-    NbtList => LIST_ID, NbtTag::List,
-    NbtCompound => COMPOUND_ID, NbtTag::Compound,
-    Vec<i32> => INT_ARRAY_ID, NbtTag::IntArray,
-    Vec<i64> => LONG_ARRAY_ID, NbtTag::LongArray
+    i8 => NbtTag::Byte,
+    i16 => NbtTag::Short,
+    i32 => NbtTag::Int,
+    i64 => NbtTag::Long,
+    f32 => NbtTag::Float,
+    f64 => NbtTag::Double,
+    Bytes => NbtTag::ByteArray,
+    String => NbtTag::String,
+    NbtList => NbtTag::List,
+    NbtCompound => NbtTag::Compound,
+    Vec<i32> => NbtTag::IntArray,
+    Vec<i64> => NbtTag::LongArray
 }
 
 #[derive(Debug, Clone, Copy)]
+#[allow(private_bounds)]
 pub struct SnbtDisplay<'a, T: NbtCompatible + PrivateNbtCompatible + ?Sized>(pub &'a T);
 impl<'a, T: NbtCompatible + ?Sized + PrivateNbtCompatible> Display for SnbtDisplay<'a, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -6,7 +6,9 @@ use derive_more::From;
 use std::fmt::{self, Display, Formatter};
 use std::io::Cursor;
 
+use crate::{TryAsMut, TryAsRef};
 use crate::nbt::list::NbtList;
+use crate::nbt::nbt_trait::NbtCompatible;
 
 /// Enum representing the different types of NBT tags.
 /// Each variant corresponds to a different type of data that can be stored in an NBT tag.
@@ -264,6 +266,46 @@ impl NbtTag {
         }
     }
 }
+impl TryAsRef<dyn NbtCompatible> for NbtTag {
+    fn try_as_ref(&self) -> Option<&dyn NbtCompatible> {
+        use self::NbtTag::*;
+        Some(match self {
+            End => return None,
+            Byte(x) => x,
+            Short(x) => x,
+            Int(x) => x,
+            Long(x) => x,
+            Float(x) => x,
+            Double(x) => x,
+            ByteArray(x) => x,
+            String(x) => x,
+            List(x) => x,
+            Compound(x) => x,
+            IntArray(x) => x,
+            LongArray(x) => x
+        })
+    }
+}
+impl TryAsMut<dyn NbtCompatible> for NbtTag {
+    fn try_as_mut(&mut self) -> Option<&mut dyn NbtCompatible> {
+        use self::NbtTag::*;
+        Some(match self {
+            End => return None,
+            Byte(x) => x,
+            Short(x) => x,
+            Int(x) => x,
+            Long(x) => x,
+            Float(x) => x,
+            Double(x) => x,
+            ByteArray(x) => x,
+            String(x) => x,
+            List(x) => x,
+            Compound(x) => x,
+            IntArray(x) => x,
+            LongArray(x) => x
+        })
+    }
+}
 
 impl From<&str> for NbtTag {
     fn from(value: &str) -> Self {
@@ -285,21 +327,9 @@ impl From<bool> for NbtTag {
 
 impl Display for NbtTag {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::End => Ok(()),
-            Self::Byte(x) => write!(f, "{x}b"),
-            Self::Short(x) => write!(f, "{x}s"),
-            Self::Int(x) => write!(f, "{x}"),
-            Self::Long(x) => write!(f, "{x}L"),
-            // using debug here matches Minecraft on whole numbers (3.0 instead of 3)
-            Self::Float(x) => write!(f, "{x:?}f"),
-            Self::Double(x) => write!(f, "{x:?}d"),
-            Self::ByteArray(arr) => write_listlike(f, "B; ", "B", arr.iter().map(|b| *b as i8)),
-            Self::String(s) => write!(f, "{}", escape_string_value(s)),
-            Self::List(list) => write!(f, "{}", list),
-            Self::Compound(compound) => write!(f, "{compound}"),
-            Self::IntArray(arr) => write_listlike(f, "I; ", "", arr),
-            Self::LongArray(arr) => write_listlike(f, "L; ", "L", arr),
+        match self.try_as_ref() {
+            None => Ok(()),
+            Some(r) => write!(f, "{}", r.snbt_dyn())
         }
     }
 }

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -6,6 +6,8 @@ use derive_more::From;
 use std::fmt::{self, Display, Formatter};
 use std::io::Cursor;
 
+use crate::nbt::list::NbtList;
+
 /// Enum representing the different types of NBT tags.
 /// Each variant corresponds to a different type of data that can be stored in an NBT tag.
 #[repr(u8)]
@@ -20,7 +22,7 @@ pub enum NbtTag {
     Double(f64) = DOUBLE_ID,
     ByteArray(Bytes) = BYTE_ARRAY_ID,
     String(String) = STRING_ID,
-    List(Vec<NbtTag>) = LIST_ID,
+    List(NbtList) = LIST_ID,
     Compound(NbtCompound) = COMPOUND_ID,
     IntArray(Vec<i32>) = INT_ARRAY_ID,
     LongArray(Vec<i64>) = LONG_ARRAY_ID,
@@ -60,8 +62,14 @@ impl NbtTag {
                 bytes.put_slice(&java_string);
             }
             NbtTag::List(list) => {
-                bytes.put_u8(list.first().unwrap_or(&NbtTag::End).get_type_id());
-                bytes.put_i32(list.len() as i32);
+                bytes.put_u8(
+                    if list.is_empty() {
+                        END_ID
+                    } else {
+                        list.get_type_id()
+                    }
+                );
+                    bytes.put_i32(list.len() as i32);
                 for nbt_tag in list {
                     bytes.put(nbt_tag.serialize_data())
                 }
@@ -228,7 +236,7 @@ impl NbtTag {
         }
     }
 
-    pub fn extract_list(&self) -> Option<&Vec<NbtTag>> {
+    pub fn extract_list(&self) -> Option<&NbtList> {
         match self {
             NbtTag::List(list) => Some(list),
             _ => None,
@@ -288,26 +296,10 @@ impl Display for NbtTag {
             Self::Double(x) => write!(f, "{x:?}d"),
             Self::ByteArray(arr) => write_listlike(f, "B; ", "B", arr.iter().map(|b| *b as i8)),
             Self::String(s) => write!(f, "{}", escape_string_value(s)),
-            Self::List(list) => write_listlike(f, "", "", list),
+            Self::List(list) => write!(f, "{}", list),
             Self::Compound(compound) => write!(f, "{compound}"),
             Self::IntArray(arr) => write_listlike(f, "I; ", "", arr),
             Self::LongArray(arr) => write_listlike(f, "L; ", "L", arr),
         }
     }
-}
-
-fn write_listlike<T: Display, I: IntoIterator<Item = T>>(
-    f: &mut Formatter<'_>,
-    prefix: &'static str,
-    affix: &'static str,
-    arr: I,
-) -> fmt::Result {
-    write!(f, "[{prefix}")?;
-    join_formatted(
-        f,
-        ", ",
-        arr.into_iter()
-            .map(|x| move |f: &mut Formatter<'_>| write!(f, "{x}{affix}")),
-    )?;
-    write!(f, "]")
 }

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -287,7 +287,7 @@ impl NbtTag {
 
     /// Returns a [Some] with a reference to a dyn [NbtCompatible],
     /// if this tag is not [NbtTag::End], else [None].
-    /// 
+    ///
     /// See also: [NbtTag::as_nbt_compatible_mut]
     pub fn as_nbt_compatible(&self) -> Option<&dyn NbtCompatible> {
         Some(call_uniform!((self), return None))
@@ -295,7 +295,7 @@ impl NbtTag {
 
     /// Returns a [Some] with a mutable reference to a dyn [NbtCompatible],
     /// if this tag is not [NbtTag::End], else [None].
-    /// 
+    ///
     /// See also: [NbtTag::as_nbt_compatible]
     pub fn as_nbt_compatible_mut(&mut self) -> Option<&mut dyn NbtCompatible> {
         Some(call_uniform!((self), return None))

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -98,7 +98,7 @@ impl NbtTag {
             ) => {
                 {
                     fn deser_helper<T: PrivateNbtCompatible>(bytes: &mut impl Buf) -> Result<T, Error> {
-                        Ok(T::deserialize_data(bytes)?)
+                        T::deserialize_data(bytes)
                     }
                     match $target {
                         END_ID => $end,

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -9,7 +9,6 @@ use std::io::Cursor;
 
 use crate::nbt::list::NbtList;
 use crate::nbt::nbt_trait::{NbtCompatible, PrivateNbtCompatible};
-use crate::{TryAsMut, TryAsRef};
 
 macro_rules! call_uniform {
     (($self:ident$(.$($expression:tt)+)?), $end_case:expr) => {
@@ -285,14 +284,20 @@ impl NbtTag {
             _ => None,
         }
     }
-}
-impl TryAsRef<dyn NbtCompatible> for NbtTag {
-    fn try_as_ref(&self) -> Option<&dyn NbtCompatible> {
+
+    /// Returns a [Some] with a reference to a dyn [NbtCompatible],
+    /// if this tag is not [NbtTag::End], else [None].
+    /// 
+    /// See also: [NbtTag::as_nbt_compatible_mut]
+    pub fn as_nbt_compatible(&self) -> Option<&dyn NbtCompatible> {
         Some(call_uniform!((self), return None))
     }
-}
-impl TryAsMut<dyn NbtCompatible> for NbtTag {
-    fn try_as_mut(&mut self) -> Option<&mut dyn NbtCompatible> {
+
+    /// Returns a [Some] with a mutable reference to a dyn [NbtCompatible],
+    /// if this tag is not [NbtTag::End], else [None].
+    /// 
+    /// See also: [NbtTag::as_nbt_compatible]
+    pub fn as_nbt_compatible_mut(&mut self) -> Option<&mut dyn NbtCompatible> {
         Some(call_uniform!((self), return None))
     }
 }

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -6,9 +6,32 @@ use derive_more::From;
 use std::fmt::{self, Display, Formatter};
 use std::io::Cursor;
 
-use crate::{TryAsMut, TryAsRef};
 use crate::nbt::list::NbtList;
-use crate::nbt::nbt_trait::NbtCompatible;
+use crate::nbt::nbt_trait::{NbtCompatible, PrivateNbtCompatible};
+use crate::{TryAsMut, TryAsRef};
+
+macro_rules! call_uniform {
+    (($self:ident$(.$($expression:tt)+)?), $end_case:expr) => {
+        {
+            use self::NbtTag::*;
+            match $self {
+                End => $end_case,
+                Byte(x) => x$(.$($expression)*)?,
+                Short(x) => x$(.$($expression)*)?,
+                Int(x) => x$(.$($expression)*)?,
+                Long(x) => x$(.$($expression)*)?,
+                Float(x) => x$(.$($expression)*)?,
+                Double(x) => x$(.$($expression)*)?,
+                ByteArray(x) => x$(.$($expression)*)?,
+                String(x) => x$(.$($expression)*)?,
+                List(x) => x$(.$($expression)*)?,
+                Compound(x) => x$(.$($expression)*)?,
+                IntArray(x) => x$(.$($expression)*)?,
+                LongArray(x) => x$(.$($expression)*)?,
+            }
+        }
+    };
+}
 
 /// Enum representing the different types of NBT tags.
 /// Each variant corresponds to a different type of data that can be stored in an NBT tag.
@@ -46,52 +69,10 @@ impl NbtTag {
 
     pub fn serialize_data(&self) -> Bytes {
         let mut bytes = BytesMut::new();
-        match self {
-            NbtTag::End => {}
-            NbtTag::Byte(byte) => bytes.put_i8(*byte),
-            NbtTag::Short(short) => bytes.put_i16(*short),
-            NbtTag::Int(int) => bytes.put_i32(*int),
-            NbtTag::Long(long) => bytes.put_i64(*long),
-            NbtTag::Float(float) => bytes.put_f32(*float),
-            NbtTag::Double(double) => bytes.put_f64(*double),
-            NbtTag::ByteArray(byte_array) => {
-                bytes.put_i32(byte_array.len() as i32);
-                bytes.put_slice(byte_array);
-            }
-            NbtTag::String(string) => {
-                let java_string = simd_cesu8::encode(string);
-                bytes.put_u16(java_string.len() as u16);
-                bytes.put_slice(&java_string);
-            }
-            NbtTag::List(list) => {
-                bytes.put_u8(
-                    if list.is_empty() {
-                        END_ID
-                    } else {
-                        list.get_type_id()
-                    }
-                );
-                    bytes.put_i32(list.len() as i32);
-                for nbt_tag in list {
-                    bytes.put(nbt_tag.serialize_data())
-                }
-            }
-            NbtTag::Compound(compound) => {
-                bytes.put(compound.serialize_content());
-            }
-            NbtTag::IntArray(int_array) => {
-                bytes.put_i32(int_array.len() as i32);
-                for int in int_array {
-                    bytes.put_i32(*int)
-                }
-            }
-            NbtTag::LongArray(long_array) => {
-                bytes.put_i32(long_array.len() as i32);
-                for long in long_array {
-                    bytes.put_i64(*long)
-                }
-            }
-        }
+        call_uniform!(
+            (self.serialize_data(&mut bytes)),
+            () // End has no data, so serialization is noop
+        );
         bytes.freeze()
     }
 
@@ -105,66 +86,48 @@ impl NbtTag {
     }
 
     pub fn deserialize_data(bytes: &mut impl Buf, tag_id: u8) -> Result<NbtTag, Error> {
-        match tag_id {
-            END_ID => Ok(NbtTag::End),
-            BYTE_ID => {
-                let byte = bytes.try_get_i8()?;
-                Ok(NbtTag::Byte(byte))
-            }
-            SHORT_ID => {
-                let short = bytes.try_get_i16()?;
-                Ok(NbtTag::Short(short))
-            }
-            INT_ID => {
-                let int = bytes.try_get_i32()?;
-                Ok(NbtTag::Int(int))
-            }
-            LONG_ID => {
-                let long = bytes.try_get_i64()?;
-                Ok(NbtTag::Long(long))
-            }
-            FLOAT_ID => {
-                let float = bytes.try_get_f32()?;
-                Ok(NbtTag::Float(float))
-            }
-            DOUBLE_ID => {
-                let double = bytes.try_get_f64()?;
-                Ok(NbtTag::Double(double))
-            }
-            BYTE_ARRAY_ID => {
-                let len = bytes.try_get_i32()? as usize;
-                let byte_array = bytes.copy_to_bytes(len);
-                Ok(NbtTag::ByteArray(byte_array))
-            }
-            STRING_ID => Ok(NbtTag::String(get_nbt_string(bytes).unwrap())),
-            LIST_ID => {
-                let tag_type_id = bytes.try_get_u8()?;
-                let len = bytes.try_get_i32()?;
-                let mut list = Vec::with_capacity(len as usize);
-                for _ in 0..len {
-                    let tag = NbtTag::deserialize_data(bytes, tag_type_id)?;
-                    assert_eq!(tag.get_type_id(), tag_type_id);
-                    list.push(tag);
+        macro_rules! gen_match {
+            (
+                {
+                    target = $target:expr,
+                    bytes = $bytes:expr,
+                    end = $end:expr,
+                    else = $else:expr
+                },
+                $($tag_id:ident => $converter:expr),*
+            ) => {
+                {
+                    fn deser_helper<T: PrivateNbtCompatible>(bytes: &mut impl Buf) -> Result<T, Error> {
+                        Ok(T::deserialize_data(bytes)?)
+                    }
+                    match $target {
+                        END_ID => $end,
+                        $($tag_id => deser_helper($bytes).map($converter)),*,
+                        _ => $else
+                    }
                 }
-                Ok(NbtTag::List(list))
-            }
-            COMPOUND_ID => Ok(NbtTag::Compound(NbtCompound::deserialize_content(bytes)?)),
-            INT_ARRAY_ID => {
-                const BYTES: usize = size_of::<i32>();
-
-                let len = bytes.try_get_i32()? as usize;
-                let numbers = read_array::<i32, BYTES, _>(bytes, len, i32::from_be_bytes);
-                Ok(NbtTag::IntArray(numbers))
-            }
-            LONG_ARRAY_ID => {
-                const BYTES: usize = size_of::<i64>();
-
-                let len = bytes.try_get_i32()? as usize;
-                let numbers = read_array::<i64, BYTES, _>(bytes, len, i64::from_be_bytes);
-                Ok(NbtTag::LongArray(numbers))
-            }
-            _ => Err(Error::UnknownTagId(tag_id)),
+            };
         }
+        gen_match!(
+            {
+                target = tag_id,
+                bytes = bytes,
+                end = Ok(NbtTag::End),
+                else = Err(Error::UnknownTagId(tag_id))
+            },
+            BYTE_ID => NbtTag::Byte,
+            SHORT_ID => NbtTag::Short,
+            INT_ID => NbtTag::Int,
+            LONG_ID => NbtTag::Long,
+            FLOAT_ID => NbtTag::Float,
+            DOUBLE_ID => NbtTag::Double,
+            BYTE_ARRAY_ID => NbtTag::ByteArray,
+            STRING_ID => NbtTag::String,
+            LIST_ID => NbtTag::List,
+            COMPOUND_ID => NbtTag::Compound,
+            INT_ARRAY_ID => NbtTag::IntArray,
+            LONG_ARRAY_ID => NbtTag::LongArray
+        )
     }
 
     pub fn deserialize_data_from_cursor(
@@ -268,42 +231,12 @@ impl NbtTag {
 }
 impl TryAsRef<dyn NbtCompatible> for NbtTag {
     fn try_as_ref(&self) -> Option<&dyn NbtCompatible> {
-        use self::NbtTag::*;
-        Some(match self {
-            End => return None,
-            Byte(x) => x,
-            Short(x) => x,
-            Int(x) => x,
-            Long(x) => x,
-            Float(x) => x,
-            Double(x) => x,
-            ByteArray(x) => x,
-            String(x) => x,
-            List(x) => x,
-            Compound(x) => x,
-            IntArray(x) => x,
-            LongArray(x) => x
-        })
+        Some(call_uniform!((self), return None))
     }
 }
 impl TryAsMut<dyn NbtCompatible> for NbtTag {
     fn try_as_mut(&mut self) -> Option<&mut dyn NbtCompatible> {
-        use self::NbtTag::*;
-        Some(match self {
-            End => return None,
-            Byte(x) => x,
-            Short(x) => x,
-            Int(x) => x,
-            Long(x) => x,
-            Float(x) => x,
-            Double(x) => x,
-            ByteArray(x) => x,
-            String(x) => x,
-            List(x) => x,
-            Compound(x) => x,
-            IntArray(x) => x,
-            LongArray(x) => x
-        })
+        Some(call_uniform!((self), return None))
     }
 }
 
@@ -327,9 +260,6 @@ impl From<bool> for NbtTag {
 
 impl Display for NbtTag {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self.try_as_ref() {
-            None => Ok(()),
-            Some(r) => write!(f, "{}", r.snbt_dyn())
-        }
+        call_uniform!((self.write_snbt(f)), Ok(()))
     }
 }

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -126,7 +126,7 @@ impl NbtTag {
         bytes.freeze()
     }
 
-    pub fn serialize_data_into(&self, bytes: &mut BytesMut) {
+    pub fn serialize_data_into(&self, bytes: &mut impl BufMut) {
         call_uniform!(
             (self.serialize_data(bytes)),
             () // End has no data, so serialization is noop

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -1,22 +1,32 @@
 use std::fmt::{self, Display, Formatter};
 
 use crate::error::Error;
-use bytes::Buf;
+use bytes::{Buf, BufMut};
+
+use crate::{NbtCompound, NbtTag, TryAsMut, TryAsRef, nbt::list::NbtList};
+use as_any::AsAny;
+use bytes::{Bytes};
 use simd_cesu8::decode;
 
-pub const END_ID: u8 = 0;
-pub const BYTE_ID: u8 = 1;
-pub const SHORT_ID: u8 = 2;
-pub const INT_ID: u8 = 3;
-pub const LONG_ID: u8 = 4;
-pub const FLOAT_ID: u8 = 5;
-pub const DOUBLE_ID: u8 = 6;
-pub const BYTE_ARRAY_ID: u8 = 7;
-pub const STRING_ID: u8 = 8;
-pub const LIST_ID: u8 = 9;
-pub const COMPOUND_ID: u8 = 10;
-pub const INT_ARRAY_ID: u8 = 11;
-pub const LONG_ARRAY_ID: u8 = 12;
+// compatibility export
+pub use ids::*;
+
+pub mod ids {
+    pub const END_ID: u8 = 0;
+    pub const BYTE_ID: u8 = 1;
+    pub const SHORT_ID: u8 = 2;
+    pub const INT_ID: u8 = 3;
+    pub const LONG_ID: u8 = 4;
+    pub const FLOAT_ID: u8 = 5;
+    pub const DOUBLE_ID: u8 = 6;
+    pub const BYTE_ARRAY_ID: u8 = 7;
+    pub const STRING_ID: u8 = 8;
+    pub const LIST_ID: u8 = 9;
+    pub const COMPOUND_ID: u8 = 10;
+    pub const INT_ARRAY_ID: u8 = 11;
+    pub const LONG_ARRAY_ID: u8 = 12;
+}
+
 
 pub fn get_nbt_string(bytes: &mut impl Buf) -> Result<String, Error> {
     let len = bytes.try_get_u16()? as usize;
@@ -43,6 +53,22 @@ where
             from_be(arr)
         })
         .collect()
+}
+
+pub(crate) fn write_listlike<T: Display, I: IntoIterator<Item = T>>(
+    f: &mut Formatter<'_>,
+    prefix: &'static str,
+    affix: &'static str,
+    arr: I,
+) -> fmt::Result {
+    write!(f, "[{prefix}")?;
+    join_formatted(
+        f,
+        ", ",
+        arr.into_iter()
+            .map(|x| move |f: &mut Formatter<'_>| write!(f, "{x}{affix}")),
+    )?;
+    write!(f, "]")
 }
 
 /// like [T]::join, but allowing for formatting

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -54,7 +54,7 @@ pub fn get_nbt_string(bytes: &mut impl Buf) -> Result<String, Error> {
     Ok(string.to_string())
 }
 
-pub fn serialize_str_into(s: &str, bytes: &mut BytesMut) {
+pub fn serialize_str_into(s: &str, bytes: &mut impl BufMut) {
     if s.is_empty() {
         bytes.put_u16(0);
         return;

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -27,6 +27,26 @@ pub mod ids {
     pub const LONG_ARRAY_ID: u8 = 12;
 }
 
+pub const fn get_nbt_type_name(id: u8) -> Option<&'static str> {
+    use ids::*;
+    Some(match id {
+        END_ID => "end",
+        BYTE_ID => "byte",
+        SHORT_ID => "short",
+        INT_ID => "int",
+        LONG_ID => "long",
+        FLOAT_ID => "float",
+        DOUBLE_ID => "double",
+        BYTE_ARRAY_ID => "byte array",
+        STRING_ID => "string",
+        LIST_ID => "list",
+        COMPOUND_ID => "compound",
+        INT_ARRAY_ID => "int array",
+        LONG_ARRAY_ID => "long array",
+        _ => return None,
+    })
+}
+
 pub fn get_nbt_string(bytes: &mut impl Buf) -> Result<String, Error> {
     let len = bytes.try_get_u16()? as usize;
     let string_bytes = bytes.copy_to_bytes(len);

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -53,11 +53,11 @@ where
 
 /// Write an arbitrary list to the [`Formatter`] `f`.
 /// Intended for SNBT serialisation.
-/// 
+///
 /// The output will look like this:
 /// `[{prefix}{elements{affix}, }*]`
 /// (Note that the last comma and space will be omitted)
-/// 
+///
 /// e.g. `write_listlike(f, "L;", "l", [1,2,3])`
 ///     will write `[L;1l, 2l, 3l]`
 pub(crate) fn write_listlike<T: Display, I: IntoIterator<Item = T>>(

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::error::Error;
-use bytes::{Buf, BufMut, BytesMut};
+use bytes::{Buf, BufMut};
 
 use simd_cesu8::decode;
 

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -1,11 +1,8 @@
 use std::fmt::{self, Display, Formatter};
 
 use crate::error::Error;
-use bytes::{Buf, BufMut};
+use bytes::Buf;
 
-use crate::{NbtCompound, NbtTag, TryAsMut, TryAsRef, nbt::list::NbtList};
-use as_any::AsAny;
-use bytes::{Bytes};
 use simd_cesu8::decode;
 
 // compatibility export
@@ -26,7 +23,6 @@ pub mod ids {
     pub const INT_ARRAY_ID: u8 = 11;
     pub const LONG_ARRAY_ID: u8 = 12;
 }
-
 
 pub fn get_nbt_string(bytes: &mut impl Buf) -> Result<String, Error> {
     let len = bytes.try_get_u16()? as usize;
@@ -55,6 +51,15 @@ where
         .collect()
 }
 
+/// Write an arbitrary list to the [`Formatter`] `f`.
+/// Intended for SNBT serialisation.
+/// 
+/// The output will look like this:
+/// `[{prefix}{elements{affix}, }*]`
+/// (Note that the last comma and space will be omitted)
+/// 
+/// e.g. `write_listlike(f, "L;", "l", [1,2,3])`
+///     will write `[L;1l, 2l, 3l]`
 pub(crate) fn write_listlike<T: Display, I: IntoIterator<Item = T>>(
     f: &mut Formatter<'_>,
     prefix: &'static str,

--- a/src/serde/nbt_types.rs
+++ b/src/serde/nbt_types.rs
@@ -1,5 +1,5 @@
-use crate::{NbtCompound, NbtTag};
-use serde::de::value::MapAccessDeserializer;
+use crate::{NbtCompound, NbtList, NbtTag};
+use serde::de::value::{MapAccessDeserializer, SeqAccessDeserializer};
 use serde::{Deserialize, Serialize};
 
 impl Serialize for NbtTag {
@@ -24,14 +24,7 @@ impl Serialize for NbtTag {
                 seq.end()
             }
             NbtTag::String(string_val) => serializer.serialize_str(string_val),
-            NbtTag::List(list_items) => {
-                use serde::ser::SerializeSeq;
-                let mut seq = serializer.serialize_seq(Some(list_items.len()))?;
-                for item in list_items.iter() {
-                    seq.serialize_element(item)?;
-                }
-                seq.end()
-            }
+            NbtTag::List(list) => list.serialize(serializer),
             NbtTag::Compound(compound) => compound.serialize(serializer),
             NbtTag::IntArray(int_array) => {
                 use serde::ser::SerializeSeq;
@@ -102,15 +95,13 @@ impl<'de> Deserialize<'de> for NbtTag {
                 Ok(NbtTag::String(value.to_owned()))
             }
 
-            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
             where
                 A: serde::de::SeqAccess<'de>,
             {
-                let mut items = Vec::new();
-                while let Some(tag) = seq.next_element()? {
-                    items.push(tag);
-                }
-                Ok(NbtTag::List(items))
+                Ok(NbtTag::List(NbtList::deserialize(
+                    SeqAccessDeserializer::new(seq),
+                )?))
             }
 
             fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
@@ -168,5 +159,120 @@ impl<'de> Deserialize<'de> for NbtCompound {
         }
 
         deserializer.deserialize_map(NbtCompoundVisitor)
+    }
+}
+
+impl Serialize for NbtList {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq as _;
+        macro_rules! helper_macro {
+            ($content:ident) => {
+                helper_macro!($content, (seq, item, seq.serialize_element(item)))
+            };
+            ($content:ident, ($seq:ident, $item:ident, $ser_expr:expr)) => {{
+                let mut $seq = serializer.serialize_seq(Some($content.len()))?;
+                for $item in $content.iter() {
+                    $ser_expr?;
+                }
+                $seq.end()
+            }};
+        }
+        use NbtList::*;
+        match self {
+            Byte(x) => helper_macro!(x),
+            Short(x) => helper_macro!(x),
+            Int(x) => helper_macro!(x),
+            Long(x) => helper_macro!(x),
+            Float(x) => helper_macro!(x),
+            Double(x) => helper_macro!(x),
+            String(x) => helper_macro!(x),
+            IntArray(x) => helper_macro!(x),
+            LongArray(x) => helper_macro!(x),
+            List(x) => helper_macro!(x),
+            Compound(x) => helper_macro!(x),
+            ByteArray(x) => helper_macro!(x, (ser, item, ser.serialize_element(&item as &[u8]))),
+            End => serializer.serialize_seq(Some(0))?.end(),
+        }
+    }
+}
+impl<'de> Deserialize<'de> for NbtList {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct NbtListVisitor;
+        impl<'de> serde::de::Visitor<'de> for NbtListVisitor {
+            type Value = NbtList;
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                struct ExpectedTagType(u8);
+                impl serde::de::Expected for ExpectedTagType {
+                    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        use crate::nbt::utils::get_nbt_type_name;
+                        write!(
+                            formatter,
+                            "an nbt {}",
+                            get_nbt_type_name(self.0)
+                                .unwrap_or("<unknown type id. please create an issue>")
+                        )
+                    }
+                }
+                let mut list = match seq.next_element::<NbtTag>()? {
+                    None => return Ok(NbtList::End),
+                    Some(tag) => {
+                        macro_rules! helper {
+                            ($tag:ident) => {
+                                helper!($tag, [Byte, Short, Int, Long, Float, Double, ByteArray, String, List, Compound, IntArray, LongArray])
+                            };
+                            ($tag:ident, [$($variant:ident),+]) => {
+                                match $tag {
+                                    NbtTag::End => return Ok(NbtList::End),
+                                    $(
+                                        NbtTag::$variant(x) => NbtList::$variant({
+                                            let mut v = seq.size_hint().map(Vec::with_capacity).unwrap_or(vec![]);
+                                            v.push(x);
+                                            v
+                                        }),
+                                    )+
+                                }
+                            };
+                        }
+                        helper!(tag)
+                    }
+                };
+                while let Some(item) = seq.next_element::<NbtTag>()? {
+                    use serde::de::Error as _;
+                    macro_rules! helper {
+                        ($tag:ident, $list:ident) => {
+                            helper!($tag, $list, [Byte, Short, Int, Long, Float, Double, ByteArray, String, List, Compound, IntArray, LongArray])
+                        };
+                        ($tag:ident, $list:ident, [$($variant:ident),+]) => {
+                            match ($tag, &mut $list) {
+                                $(
+                                    (NbtTag::$variant(x), NbtList::$variant(v)) => { v.push(x); }
+                                )+,
+                                (_, _) => return Err(A::Error::invalid_type(
+                                    serde::de::Unexpected::Other(""),
+                                    &ExpectedTagType($list.get_content_type_id())
+                                ))
+                            }
+                        };
+                    }
+                    helper!(item, list);
+                }
+                Ok(list)
+            }
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(formatter, "an NBT List")
+            }
+        }
+        deserializer.deserialize_seq(NbtListVisitor)
     }
 }

--- a/src/serde/nbt_types.rs
+++ b/src/serde/nbt_types.rs
@@ -193,7 +193,7 @@ impl Serialize for NbtList {
             LongArray(x) => helper_macro!(x),
             List(x) => helper_macro!(x),
             Compound(x) => helper_macro!(x),
-            ByteArray(x) => helper_macro!(x, (ser, item, ser.serialize_element(&item as &[u8]))),
+            ByteArray(x) => helper_macro!(x, (ser, item, ser.serialize_element(item as &[u8]))),
             End => serializer.serialize_seq(Some(0))?.end(),
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,9 @@
+
+// TODO: Is it really a good idea to introduce two generic traits in an NBT library?
+
+pub trait TryAsRef<T: ?Sized> {
+    fn try_as_ref(&self) -> Option<&T>;
+}
+pub trait TryAsMut<T: ?Sized> {
+    fn try_as_mut(&mut self) -> Option<&mut T>;
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,0 @@
-// TODO: Is it really a good idea to introduce two generic traits in an NBT library?
-
-pub trait TryAsRef<T: ?Sized> {
-    fn try_as_ref(&self) -> Option<&T>;
-}
-pub trait TryAsMut<T: ?Sized> {
-    fn try_as_mut(&mut self) -> Option<&mut T>;
-}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,3 @@
-
 // TODO: Is it really a good idea to introduce two generic traits in an NBT library?
 
 pub trait TryAsRef<T: ?Sized> {

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -29,7 +29,7 @@ fn nbt_macro_handles_array_content() {
 
     let array = nbt.get_list("array").unwrap();
 
-    assert_eq!(array, &vec![1.into(), 2.into(), 3.into()]);
+    assert_eq!(array, &vec![1, 2, 3].into());
 }
 
 #[test]
@@ -55,7 +55,7 @@ fn nbt_macro_complex_object() {
             ("int_array".to_owned(), NbtTag::IntArray(vec![1])),
             (
                 "list".to_owned(),
-                NbtTag::List(vec!["a".into(), "b".into(), "c".into()]),
+                NbtTag::List(vec!["a".to_string(), "b".to_string(), "c".to_string()].into()),
             ),
             (
                 "nbt_inner".to_owned(),


### PR DESCRIPTION
This is an implementation of the fix I have outlined in #46 (see [this message](https://github.com/CrabCraftDev/CrabNBT/pull/46#issuecomment-4926772396)) to fix #45 namely the fact that we currently allow heterogeneous lists to be created (and serialize them), which is not standard NBT.

## Summary
This pull request statically enforces that nbt lists created through this library are homogenous.
It does this by introducing a new `NbtList` enum, whose variants correspond to the possible content types of an `NbtList`.

It also introduces a new trait `NbtCompatible` implemented by types that can be directly stored in an nbt data structure. Implementors are primitives such as `i8` and `String`, but also `NbtCompound` and `NbtList` itself. The purpose of this trait is firstly to allow usage of generics and secondly for its trait object. Any `NbtCompatible` type can be wrapped into an NbtTag using `into_tag`.

Inspection methods such as `get` and `iter` are implemented on `NbtList` to return references to the elements as `dyn NbtCompatible` trait objects. These trait objects support general methods such as SNBT displays as well as downcasting into its possible types using `as_concrete` and `as_concrete_mut`.

To aid in working with `NbtList`, this pull request adds and exports `nbt_list_call_uniform!`, which expands to a match statement running the same expression on multiple possible values. Refer to the documentation for more details.

## Performance
Serde (R/W) and normal write performance is approximately equal. Normal write is slightly faster (likely because of smaller allocations).

`NbtTag` is the same size.

Heap memory used per element in an NBT list is now exactly equal to the content type's size (Best: 1, Worst: 32) from (Best: 40, Worst: 40).

## ToDo

- [x]  revisit `nbt_list_call_uniform`

  - current syntax is somewhat unintuitive
  - limited in that it only allows a single expression. Ideally we would have a syntax like this:
    ```
    nbt_list_call_uniform!(
        (Byte | Short | Integer | Float | Double)(x) => (2*x).into_tag(),
        _ => panic!("Cannot double non-number values)
    )
    ```
  - this would also help to remedy concerns of code verbosity
- [ ] consider renaming `nbt_list_call_uniform`

  - feature scope of the macro has now expanded enough that multiple expressions are supported, so an argument could be made that it is no longer uniform.