### PR TITLE
perf: reuse allocs in serialization

### DIFF
--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -1,7 +1,6 @@
 use crate::error::Error;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crab_nbt::nbt::compound::NbtCompound;
-use crab_nbt::nbt::tag::NbtTag;
 use crab_nbt::nbt::utils::*;
 use std::fmt::{self, Display, Formatter};
 use std::io::{Cursor, Write};
@@ -71,7 +70,7 @@ impl Nbt {
 
     pub fn write_into(&self, bytes: &mut BytesMut) {
         bytes.put_u8(COMPOUND_ID);
-        NbtTag::serialize_str_into(&self.name, bytes);
+        serialize_str_into(&self.name, bytes);
         self.root_tag.serialize_content_into(bytes);
     }
 

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -65,10 +65,14 @@ impl Nbt {
 
     pub fn write(&self) -> Bytes {
         let mut bytes = BytesMut::new();
-        bytes.put_u8(COMPOUND_ID);
-        bytes.put(NbtTag::String(self.name.to_string()).serialize_data());
-        bytes.put(self.root_tag.serialize_content());
+        self.write_into(&mut bytes);
         bytes.freeze()
+    }
+
+    pub fn write_into(&self, bytes: &mut BytesMut) {
+        bytes.put_u8(COMPOUND_ID);
+        NbtTag::serialize_str_into(&self.name, bytes);
+        self.root_tag.serialize_content_into(bytes);
     }
 
     pub fn write_to_writer<W: Write>(&self, mut writer: W) -> Result<(), Error> {
@@ -80,9 +84,13 @@ impl Nbt {
     /// Used in [Network NBT](https://wiki.vg/NBT#Network_NBT_(Java_Edition)).
     pub fn write_unnamed(&self) -> Bytes {
         let mut bytes = BytesMut::new();
-        bytes.put_u8(COMPOUND_ID);
-        bytes.put(self.root_tag.serialize_content());
+        self.write_unnamed_into(&mut bytes);
         bytes.freeze()
+    }
+
+    pub fn write_unnamed_into(&self, bytes: &mut BytesMut) {
+        bytes.put_u8(COMPOUND_ID);
+        self.root_tag.serialize_content_into(bytes);
     }
 
     pub fn write_unnamed_to_writer<W: Write>(&self, mut writer: W) -> Result<(), Error> {

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -49,13 +49,17 @@ impl NbtCompound {
 
     pub fn serialize_content(&self) -> Bytes {
         let mut bytes = BytesMut::new();
+        self.serialize_content_into(&mut bytes);
+        bytes.freeze()
+    }
+
+    pub fn serialize_content_into(&self, bytes: &mut BytesMut) {
         for (name, tag) in &self.child_tags {
             bytes.put_u8(tag.get_type_id());
-            bytes.put(NbtTag::String(name.clone()).serialize_data());
-            bytes.put(tag.serialize_data());
+            NbtTag::serialize_str_into(name, bytes);
+            tag.serialize_data_into(bytes);
         }
         bytes.put_u8(END_ID);
-        bytes.freeze()
     }
 
     pub fn serialize_content_to_writer<W: Write>(&self, mut writer: W) -> Result<(), Error> {

--- a/src/nbt/compound.rs
+++ b/src/nbt/compound.rs
@@ -1,4 +1,4 @@
-use crate::nbt::utils::{escape_name, join_formatted};
+use crate::nbt::utils::{escape_name, join_formatted, serialize_str_into};
 use crate::{error::Error, Nbt};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use crab_nbt::nbt::tag::NbtTag;
@@ -56,7 +56,7 @@ impl NbtCompound {
     pub fn serialize_content_into(&self, bytes: &mut BytesMut) {
         for (name, tag) in &self.child_tags {
             bytes.put_u8(tag.get_type_id());
-            NbtTag::serialize_str_into(name, bytes);
+            serialize_str_into(name, bytes);
             tag.serialize_data_into(bytes);
         }
         bytes.put_u8(END_ID);

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -35,13 +35,33 @@ impl NbtTag {
 
     pub fn serialize(&self) -> Bytes {
         let mut bytes = BytesMut::new();
-        bytes.put_u8(self.get_type_id());
-        bytes.put(self.serialize_data());
+        self.serialize_into(&mut bytes);
         bytes.freeze()
+    }
+
+    pub fn serialize_into(&self, bytes: &mut BytesMut) {
+        bytes.put_u8(self.get_type_id());
+        self.serialize_data_into(bytes);
+    }
+
+    pub fn serialize_str_into(s: &str, bytes: &mut BytesMut) {
+        if s.is_empty() {
+            bytes.put_u16(0);
+            return;
+        }
+
+        let java_string = simd_cesu8::encode(s);
+        bytes.put_u16(java_string.len() as u16);
+        bytes.put_slice(&java_string);
     }
 
     pub fn serialize_data(&self) -> Bytes {
         let mut bytes = BytesMut::new();
+        self.serialize_data_into(&mut bytes);
+        bytes.freeze()
+    }
+
+    pub fn serialize_data_into(&self, bytes: &mut BytesMut) {
         match self {
             NbtTag::End => {}
             NbtTag::Byte(byte) => bytes.put_i8(*byte),
@@ -54,21 +74,15 @@ impl NbtTag {
                 bytes.put_i32(byte_array.len() as i32);
                 bytes.put_slice(byte_array);
             }
-            NbtTag::String(string) => {
-                let java_string = simd_cesu8::encode(string);
-                bytes.put_u16(java_string.len() as u16);
-                bytes.put_slice(&java_string);
-            }
+            NbtTag::String(string) => Self::serialize_str_into(string, bytes),
             NbtTag::List(list) => {
                 bytes.put_u8(list.first().unwrap_or(&NbtTag::End).get_type_id());
                 bytes.put_i32(list.len() as i32);
                 for nbt_tag in list {
-                    bytes.put(nbt_tag.serialize_data())
+                    nbt_tag.serialize_data_into(bytes);
                 }
             }
-            NbtTag::Compound(compound) => {
-                bytes.put(compound.serialize_content());
-            }
+            NbtTag::Compound(compound) => compound.serialize_content_into(bytes),
             NbtTag::IntArray(int_array) => {
                 bytes.put_i32(int_array.len() as i32);
                 for int in int_array {
@@ -82,7 +96,6 @@ impl NbtTag {
                 }
             }
         }
-        bytes.freeze()
     }
 
     pub fn deserialize(bytes: &mut impl Buf) -> Result<NbtTag, Error> {

--- a/src/nbt/tag.rs
+++ b/src/nbt/tag.rs
@@ -44,17 +44,6 @@ impl NbtTag {
         self.serialize_data_into(bytes);
     }
 
-    pub fn serialize_str_into(s: &str, bytes: &mut BytesMut) {
-        if s.is_empty() {
-            bytes.put_u16(0);
-            return;
-        }
-
-        let java_string = simd_cesu8::encode(s);
-        bytes.put_u16(java_string.len() as u16);
-        bytes.put_slice(&java_string);
-    }
-
     pub fn serialize_data(&self) -> Bytes {
         let mut bytes = BytesMut::new();
         self.serialize_data_into(&mut bytes);
@@ -74,7 +63,7 @@ impl NbtTag {
                 bytes.put_i32(byte_array.len() as i32);
                 bytes.put_slice(byte_array);
             }
-            NbtTag::String(string) => Self::serialize_str_into(string, bytes),
+            NbtTag::String(string) => serialize_str_into(string, bytes),
             NbtTag::List(list) => {
                 bytes.put_u8(list.first().unwrap_or(&NbtTag::End).get_type_id());
                 bytes.put_i32(list.len() as i32);

--- a/src/nbt/utils.rs
+++ b/src/nbt/utils.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use crate::error::Error;
-use bytes::Buf;
+use bytes::{Buf, BufMut, BytesMut};
 use simd_cesu8::decode;
 
 pub const END_ID: u8 = 0;
@@ -23,6 +23,17 @@ pub fn get_nbt_string(bytes: &mut impl Buf) -> Result<String, Error> {
     let string_bytes = bytes.copy_to_bytes(len);
     let string = decode(&string_bytes).map_err(|_| Error::InvalidJavaString)?;
     Ok(string.to_string())
+}
+
+pub fn serialize_str_into(s: &str, bytes: &mut BytesMut) {
+    if s.is_empty() {
+        bytes.put_u16(0);
+        return;
+    }
+
+    let java_string = simd_cesu8::encode(s);
+    bytes.put_u16(java_string.len() as u16);
+    bytes.put_slice(&java_string);
 }
 
 // This can be improved once rust-lang/rust#132980 is resolved:

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -1,7 +1,6 @@
 use crate::error::Error::UnsupportedType;
 use crate::error::{Error, Result};
 use crate::nbt::utils::*;
-use crate::NbtTag;
 use bytes::{BufMut, BytesMut};
 use crab_nbt::nbt::utils::END_ID;
 use serde::ser::Impossible;
@@ -32,7 +31,7 @@ impl Serializer {
         match &mut self.state {
             State::Named(name) | State::Array { name, .. } => {
                 self.output.put_u8(tag);
-                NbtTag::serialize_str_into(&name, &mut self.output);
+                serialize_str_into(name, &mut self.output);
             }
             State::FirstListElement { len } => {
                 self.output.put_u8(tag);
@@ -177,7 +176,7 @@ impl ser::Serializer for &mut Serializer {
             return Ok(());
         }
 
-        NbtTag::serialize_str_into(&v, &mut self.output);
+        serialize_str_into(v, &mut self.output);
         Ok(())
     }
 
@@ -330,11 +329,11 @@ impl ser::Serializer for &mut Serializer {
         match &mut self.state {
             State::Root(root_name) => {
                 if let Some(root_name) = root_name {
-                    NbtTag::serialize_str_into(&root_name, &mut self.output);
+                    serialize_str_into(root_name, &mut self.output);
                 }
             }
             State::Named(string) => {
-                NbtTag::serialize_str_into(&string, &mut self.output);
+                serialize_str_into(string, &mut self.output);
             }
             State::FirstListElement { len } => {
                 self.output.put_i32(*len);

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -32,8 +32,7 @@ impl Serializer {
         match &mut self.state {
             State::Named(name) | State::Array { name, .. } => {
                 self.output.put_u8(tag);
-                self.output
-                    .put(NbtTag::String(name.clone()).serialize_data());
+                NbtTag::serialize_str_into(&name, &mut self.output);
             }
             State::FirstListElement { len } => {
                 self.output.put_u8(tag);
@@ -178,8 +177,7 @@ impl ser::Serializer for &mut Serializer {
             return Ok(());
         }
 
-        self.output
-            .put(NbtTag::String(v.to_string()).serialize_data());
+        NbtTag::serialize_str_into(&v, &mut self.output);
         Ok(())
     }
 
@@ -332,13 +330,11 @@ impl ser::Serializer for &mut Serializer {
         match &mut self.state {
             State::Root(root_name) => {
                 if let Some(root_name) = root_name {
-                    self.output
-                        .put(NbtTag::String(root_name.clone()).serialize_data());
+                    NbtTag::serialize_str_into(&root_name, &mut self.output);
                 }
             }
             State::Named(string) => {
-                self.output
-                    .put(NbtTag::String(string.clone()).serialize_data());
+                NbtTag::serialize_str_into(&string, &mut self.output);
             }
             State::FirstListElement { len } => {
                 self.output.put_i32(*len);


### PR DESCRIPTION
main branch version of #50 
vs main:
```
read/complex_player     time:   [12.801 µs 12.988 µs 13.187 µs]
                        thrpt:  [244.45 MiB/s 248.18 MiB/s 251.82 MiB/s]
                 change:
                        time:   [-3.9509% -1.1581% +1.9716%] (p = 0.43 > 0.05)
                        thrpt:  [-1.9335% +1.1717% +4.1134%]
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  9 (9.00%) low mild
  1 (1.00%) high mild

read/chunk              time:   [39.183 µs 39.850 µs 40.602 µs]
                        thrpt:  [1.0168 GiB/s 1.0361 GiB/s 1.0537 GiB/s]
                 change:
                        time:   [-2.6364% +1.0505% +4.8395%] (p = 0.57 > 0.05)
                        thrpt:  [-4.6161% -1.0396% +2.7078%]
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

     Running benches/write.rs (target/release/deps/write-c5d68cceaef7608a)
write/complex_player    time:   [4.4602 µs 4.4801 µs 4.4963 µs]
                        thrpt:  [716.91 MiB/s 719.49 MiB/s 722.70 MiB/s]
                 change:
                        time:   [-82.990% -82.743% -82.497%] (p = 0.00 < 0.05)
                        thrpt:  [+471.34% +479.46% +487.88%]
                        Performance has improved.

write/chunk             time:   [20.042 µs 20.266 µs 20.484 µs]
                        thrpt:  [2.0155 GiB/s 2.0372 GiB/s 2.0600 GiB/s]
                 change:
                        time:   [-75.588% -75.030% -74.443%] (p = 0.00 < 0.05)
                        thrpt:  [+291.28% +300.47% +309.64%]
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  15 (15.00%) low mild
  ```