### PR TITLE
feat: gungraun benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1.0.218", optional = true, features = ["derive"] }
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
 flate2 = "1.1.0"
+gungraun = "0.19.4"
 
 [package.metadata."docs.rs"]
 all-features = true
@@ -45,4 +46,9 @@ harness = false
 
 [[bench]]
 name = "write"
+harness = false
+
+[[bench]]
+name = "gungraun"
+bench = false
 harness = false

--- a/benches/gungraun.rs
+++ b/benches/gungraun.rs
@@ -1,0 +1,40 @@
+use bytes::Bytes;
+use crab_nbt::Nbt;
+use gungraun::{prelude::*, Dhat};
+use std::hint::black_box;
+
+#[cfg(feature = "serde")]
+#[path = "../tests/serde/test_data_definitions.rs"]
+mod test_data_definitions;
+#[path = "../tests/utils.rs"]
+mod utils;
+
+fn read_file(path: &str) -> Bytes {
+    utils::read_file(path, true)
+}
+
+fn read_file_to_nbt(path: &str) -> Nbt {
+    Nbt::read(&mut read_file(path)).expect("Failed to read NBT")
+}
+
+#[library_benchmark]
+#[bench::complex_player(args = ("tests/data/complex_player.dat"), setup = read_file)]
+#[bench::chunk(args = ("tests/data/chunk.nbt"), setup = read_file)]
+fn read(value: Bytes) -> Nbt {
+    black_box(Nbt::read(&mut black_box(value))).expect("Failed to parse NBT")
+}
+
+#[library_benchmark]
+#[bench::complex_player(args = ("tests/data/complex_player.dat"), setup = read_file_to_nbt)]
+#[bench::chunk(args = ("tests/data/chunk.nbt"), setup = read_file_to_nbt)]
+fn write(value: Nbt) -> Bytes {
+    black_box(black_box(value).write())
+}
+
+library_benchmark_group!(name = read_group, benchmarks = read);
+library_benchmark_group!(name = write_group, benchmarks = write);
+
+main!(
+    config = LibraryBenchmarkConfig::default().tool(Dhat::default()),
+    library_benchmark_groups = [read_group, write_group]
+);


### PR DESCRIPTION
disabled by default due to requiring valgrind (thus limiting it to certain operating systems), run with `cargo bench --bench gungraun`